### PR TITLE
fix(recording): allow 0.0.0.0:3000 to be safely called without https

### DIFF
--- a/api/src/services/cdp.service.ts
+++ b/api/src/services/cdp.service.ts
@@ -358,6 +358,7 @@ export class CDPService extends EventEmitter {
       "--use-angle=disabled",
       "--disable-blink-features=AutomationControlled",
       "--disable-software-rasterizer",
+      "--unsafely-treat-insecure-origin-as-secure=http://0.0.0.0:3000,http://localhost:3000",
       `--window-size=${this.launchConfig.dimensions?.width ?? 1920},${this.launchConfig.dimensions?.height ?? 1080}`,
       `--timezone=${timezone}`,
       userAgent ? `--user-agent=${userAgent}` : "",


### PR DESCRIPTION
## Bugfix
* Allow for recordings to work when deployed and binded to 0.0.0.0