### PR TITLE
Add gitattributes to ensure line endings are set to LF for all OSs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.sh text eol=lf
+*.conf text eol=lf


### PR DESCRIPTION
There's an issue when running on windows where the repo gets cloned with CLRF line endings which makes the entrypoint.sh file not able to be found