### PR TITLE
fix: add support for 'Program Files (x86)' path

### DIFF
--- a/api/src/utils/browser.ts
+++ b/api/src/utils/browser.ts
@@ -1,9 +1,17 @@
+import fs from 'fs';
 import path from "path";
 import { Page } from "puppeteer-core";
 
 export const getChromeExecutablePath = () => {
   if (process.platform === "win32") {
-    return `${process.env["ProgramFiles"]}\\Google\\Chrome\\Application\\chrome.exe`;
+    const programFilesPath = `${process.env["ProgramFiles"]}\\Google\\Chrome\\Application\\chrome.exe`;
+    const programFilesX86Path = `C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe`;
+
+    if (fs.existsSync(programFilesPath)) {
+        return programFilesPath;
+    } else if (fs.existsSync(programFilesX86Path)) {
+        return programFilesX86Path;
+    }
   }
 
   if (process.platform === "darwin") {


### PR DESCRIPTION
Hello! I noticed that `app/src/utils/browser.ts` does not support "Program Files (x86)" directory.

I modified it to include checking Chrome installations in "Program Files (x86)" paths.