### PR TITLE
Optimize Dockerfile to reduce number of layers and speedup build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 node_modules/
+build/
 **/.env
 **/.env.local
+Dockerfile
+docker-compose.yml

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,19 +4,35 @@ FROM node:${NODE_VERSION}-slim AS base
 
 WORKDIR /app
 
-ENV NODE_ENV="production"
-ENV PUPPETEER_CACHE_DIR=/app/.cache
-ENV DISPLAY=:10
-ENV PATH="/usr/bin:/app/selenium/driver:${PATH}"
-ENV CHROME_BIN=/usr/bin/google-chrome-stable
-ENV CHROME_PATH=/usr/bin/google-chrome-stable
+ENV NODE_ENV="production" \
+    PUPPETEER_CACHE_DIR=/app/.cache \
+    DISPLAY=:10 \
+    PATH="/usr/bin:/app/selenium/driver:${PATH}" \
+    CHROME_BIN=/usr/bin/google-chrome-stable \
+    CHROME_PATH=/usr/bin/google-chrome-stable
 
 LABEL org.opencontainers.image.source="https://github.com/steel-dev/steel-browser"
 
+# Install dependencies
+# Using --mount to speed up build with caching, see https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mount
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=tmpfs,target=/var/log/apt \
+    rm -f /etc/apt/apt.conf.d/docker-clean; \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache; \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade
+
 FROM base AS build
 
-RUN apt-get update -qq && \
-    apt-get install -y build-essential pkg-config python-is-python3 xvfb
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=tmpfs,target=/var/log/apt \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      build-essential \
+      pkg-config \
+      python-is-python3 \
+      xvfb
 
 COPY --link package-lock.json package.json ./
 
@@ -34,41 +50,53 @@ WORKDIR /app/patcher
 RUN npm i --include=dev
 RUN node ./scripts/patcher.js patch --packagePath /app/node_modules/puppeteer-core
 
-FROM base
-WORKDIR /app
-RUN apt-get update \
-    && apt-get install -y wget nginx gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+FROM base AS production
+# Install dependencies
+# Using --mount to speed up build with caching, see https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mount
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=tmpfs,target=/var/log/apt \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+      wget \
+      nginx \
+      gnupg \
+      fonts-ipafont-gothic \
+      fonts-wqy-zenhei \
+      fonts-thai-tlwg \
+      fonts-kacst \
+      fonts-freefont-ttf \
+      libxss1 \
+      xvfb \
+      curl \
+      unzip \
+      default-jre \
+      dbus \
+      dbus-x11
+
+# Install Chrome and ChromeDriver
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=tmpfs,target=/var/log/apt \
+    # wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     # && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' <- add this back in when supported \ 
-    && apt-get update \
-    && apt-get install -y fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 xvfb curl unzip default-jre dbus dbus-x11 \
-    --no-install-recommends
-
-RUN curl -o chrome.deb https://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_128.0.6613.119-1_amd64.deb \
+    # && apt-get update \
+    curl -o chrome.deb https://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_128.0.6613.119-1_amd64.deb \
     && apt-get install -y ./chrome.deb \
-    && rm chrome.deb
-
-
-RUN mkdir -p /selenium/driver \
+    && rm chrome.deb \
+    && mkdir -p /selenium/driver \
     && curl -o chromedriver.zip https://storage.googleapis.com/chrome-for-testing-public/128.0.6613.119/linux64/chromedriver-linux64.zip \
     && unzip chromedriver.zip -d /tmp \
     && mv /tmp/chromedriver-linux64/chromedriver /selenium/driver/chromedriver \
     && rm -rf chromedriver.zip /tmp/chromedriver-linux64 \
-    && chmod +x /selenium/driver/chromedriver \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && chmod +x /selenium/driver/chromedriver
 
-COPY --from=patcher /app /app
+COPY --chmod=755 entrypoint.sh /app/entrypoint.sh
 
-COPY entrypoint.sh /app/entrypoint.sh
+EXPOSE 3000 9223
 
-RUN chmod +x /app/entrypoint.sh
-
-EXPOSE 3000
-EXPOSE 9223
-
-ENV HOST_IP=localhost
-# Set the DISPLAY environment variable
-ENV DISPLAY=:10
-ENV DBUS_SESSION_BUS_ADDRESS=autolaunch:
+ENV HOST_IP=localhost \
+    DBUS_SESSION_BUS_ADDRESS=autolaunch:
 
 ENTRYPOINT ["/app/entrypoint.sh"]
+
+COPY --from=patcher /app /app


### PR DESCRIPTION
I just noticed that Docker image for API builds a little bit longer than I expected, so I applied a few optimizations to speed consecutive builds.

 1. Use RUN --mount to cache OS package files and metadata
 2. Reorder instructions so changes in source code invalidate less build steps
 3. Reduce number of resulting layers (there is a limit)
 4. Eliminate some duplications (like `DISPLAY` env)