### PR TITLE
Measure traffic usage if proxy server is specified

### DIFF
--- a/api/src/modules/actions/actions.routes.ts
+++ b/api/src/modules/actions/actions.routes.ts
@@ -18,7 +18,7 @@ async function routes(server: FastifyInstance) {
         },
       },
     },
-    async (request: ScrapeRequest, reply: FastifyReply) => handleScrape(server.cdpService, request, reply),
+    async (request: ScrapeRequest, reply: FastifyReply) => handleScrape(server.sessionService, server.cdpService, request, reply),
   );
 
   server.post(
@@ -35,7 +35,7 @@ async function routes(server: FastifyInstance) {
         },
       },
     },
-    async (request: ScreenshotRequest, reply: FastifyReply) => handleScreenshot(server.cdpService, request, reply),
+    async (request: ScreenshotRequest, reply: FastifyReply) => handleScreenshot(server.sessionService, server.cdpService, request, reply),
   );
 
   server.post(
@@ -52,7 +52,7 @@ async function routes(server: FastifyInstance) {
         },
       },
     },
-    async (request: PDFRequest, reply: FastifyReply) => handlePDF(server.cdpService, request, reply),
+    async (request: PDFRequest, reply: FastifyReply) => handlePDF(server.sessionService, server.cdpService, request, reply),
   );
 }
 

--- a/api/src/modules/actions/actions.schema.ts
+++ b/api/src/modules/actions/actions.schema.ts
@@ -7,7 +7,7 @@ const ScrapeRequest = z.object({
   format: z.array(z.nativeEnum(ScrapeFormat)).optional(),
   screenshot: z.boolean().optional(),
   pdf: z.boolean().optional(),
-  proxyUrl: z.string().optional(),
+  proxyUrl: z.string().nullable().optional().describe("Proxy URL to use for the scrape. Provide `null` to disable proxy. If not provided, current session proxy settings will be used."),
   delay: z.number().optional(),
   logUrl: z.string().optional(),
 });
@@ -38,7 +38,7 @@ const ScrapeResponse = z.object({
 
 const ScreenshotRequest = z.object({
   url: z.string(),
-  proxyUrl: z.string().optional(),
+  proxyUrl: z.string().nullable().optional().describe("Proxy URL to use for the scrape. Provide `null` to disable proxy. If not provided, current session proxy settings will be used."),
   delay: z.number().optional(),
   fullPage: z.boolean().optional(),
   logUrl: z.string().optional(),
@@ -48,7 +48,7 @@ const ScreenshotResponse = z.any();
 
 const PDFRequest = z.object({
   url: z.string(),
-  proxyUrl: z.string().optional(),
+  proxyUrl: z.string().nullable().optional().describe("Proxy URL to use for PDF export. Provide `null` to disable proxy. If not provided, current session proxy settings will be used."),
   delay: z.number().optional(),
   logUrl: z.string().optional(),
 });

--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -42,9 +42,9 @@ export const handleExitBrowserSession = async (
   reply: FastifyReply,
 ) => {
   try {
-    await server.sessionService.endSession();
+    const oldSession = await server.sessionService.endSession();
 
-    reply.send({ success: true });
+    reply.send(oldSession);
   } catch (e: unknown) {
     const error = getErrors(e);
     return reply.code(500).send({ success: false, message: error });

--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -42,9 +42,9 @@ export const handleExitBrowserSession = async (
   reply: FastifyReply,
 ) => {
   try {
-    const oldSession = await server.sessionService.endSession();
+    const sessionDetails = await server.sessionService.endSession();
 
-    reply.send(oldSession);
+    reply.send({ success: true, ...sessionDetails });
   } catch (e: unknown) {
     const error = getErrors(e);
     return reply.code(500).send({ success: false, message: error });

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -99,6 +99,9 @@ async function routes(server: FastifyInstance) {
         description: "Release a browser session",
         tags: ["Sessions"],
         summary: "Release a browser session",
+        response: {
+          200: $ref("SessionDetails"),
+        },
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) =>
@@ -113,6 +116,9 @@ async function routes(server: FastifyInstance) {
         description: "Release browser sessions",
         tags: ["Sessions"],
         summary: "Release browser sessions",
+        response: {
+          200: $ref("SessionDetails"),
+        },
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) =>

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -100,7 +100,7 @@ async function routes(server: FastifyInstance) {
         tags: ["Sessions"],
         summary: "Release a browser session",
         response: {
-          200: $ref("SessionDetails"),
+          200: $ref("ReleaseSession"),
         },
       },
     },
@@ -117,7 +117,7 @@ async function routes(server: FastifyInstance) {
         tags: ["Sessions"],
         summary: "Release browser sessions",
         response: {
-          200: $ref("SessionDetails"),
+          200: $ref("ReleaseSession"),
         },
       },
     },

--- a/api/src/modules/sessions/sessions.schema.ts
+++ b/api/src/modules/sessions/sessions.schema.ts
@@ -34,6 +34,8 @@ const SessionDetails = z.object({
   sessionViewerUrl: z.string().describe("URL to view session details"),
   userAgent: z.string().optional().describe("User agent string used in the session"),
   proxy: z.string().optional().describe("Proxy server used for the session"),
+  proxyTxBytes: z.number().int().nonnegative().describe("Amount of data transmitted through the proxy"),
+  proxyRxBytes: z.number().int().nonnegative().describe("Amount of data received through the proxy"),
   solveCaptcha: z.boolean().optional().describe("Indicates if captcha solving is enabled"),
   isSelenium: z.boolean().optional().describe("Indicates if Selenium is used in the session"),
 });
@@ -49,10 +51,7 @@ const MultipleSessions = z.array(SessionDetails);
 export type CreateSessionBody = z.infer<typeof CreateSession>;
 export type CreateSessionRequest = FastifyRequest<{ Body: CreateSessionBody }>;
 
-export type SessionDetails = z.infer<typeof SessionDetails> & {
-  completion: Promise<void>,
-  complete: (value: void) => void,
-};
+export type SessionDetails = z.infer<typeof SessionDetails>;
 export type MultipleSessions = z.infer<typeof MultipleSessions>;
 export const browserSchemas = {
   CreateSession,

--- a/api/src/modules/sessions/sessions.schema.ts
+++ b/api/src/modules/sessions/sessions.schema.ts
@@ -40,6 +40,8 @@ const SessionDetails = z.object({
   isSelenium: z.boolean().optional().describe("Indicates if Selenium is used in the session"),
 });
 
+const ReleaseSession = SessionDetails.merge(z.object({ success: z.boolean().describe("Indicates if the session was successfully released") }));
+
 const RecordedEvents = z.object({
   events: z.array(z.any()).describe("Events to emit"),
 });
@@ -58,6 +60,7 @@ export const browserSchemas = {
   SessionDetails,
   MultipleSessions,
   RecordedEvents,
+  ReleaseSession,
 };
 
 export default browserSchemas;

--- a/api/src/services/selenium.service.ts
+++ b/api/src/services/selenium.service.ts
@@ -3,7 +3,6 @@ import { ChildProcess, spawn } from "child_process";
 import { BrowserLauncherOptions, BrowserEvent, BrowserEventType } from "../types";
 import path from "path";
 import { FastifyBaseLogger } from "fastify";
-import { ProxyServer } from "../utils/proxy";
 
 export class SeleniumService extends EventEmitter {
   private seleniumProcess: ChildProcess | null = null;
@@ -19,13 +18,12 @@ export class SeleniumService extends EventEmitter {
 
   public async getChromeArgs(): Promise<string[]> {
     const { options, userAgent } = this.launchOptions ?? {};
-    const proxy = options?.proxyUrl ? new ProxyServer(options.proxyUrl) : null;
     return [
       "disable-dev-shm-usage",
       "no-sandbox",
       "enable-javascript",
       userAgent ? `user-agent=${userAgent}` : "",
-      proxy ? `proxy-server=${proxy.url}` : "",
+      options?.proxyUrl ? `proxy-server=${options.proxyUrl}` : "",
       ...(options?.args?.map((arg) => (arg.startsWith("--") ? arg.slice(2) : arg)) || []),
     ].filter(Boolean);
   }

--- a/api/src/services/selenium.service.ts
+++ b/api/src/services/selenium.service.ts
@@ -3,7 +3,7 @@ import { ChildProcess, spawn } from "child_process";
 import { BrowserLauncherOptions, BrowserEvent, BrowserEventType } from "../types";
 import path from "path";
 import { FastifyBaseLogger } from "fastify";
-const proxyChain = require("proxy-chain");
+import { ProxyServer } from "../utils/proxy";
 
 export class SeleniumService extends EventEmitter {
   private seleniumProcess: ChildProcess | null = null;
@@ -19,13 +19,13 @@ export class SeleniumService extends EventEmitter {
 
   public async getChromeArgs(): Promise<string[]> {
     const { options, userAgent } = this.launchOptions ?? {};
-    const proxyUrl = options?.proxyUrl ? await proxyChain.anonymizeProxy(options.proxyUrl) : null;
+    const proxy = options?.proxyUrl ? new ProxyServer(options.proxyUrl) : null;
     return [
       "disable-dev-shm-usage",
       "no-sandbox",
       "enable-javascript",
       userAgent ? `user-agent=${userAgent}` : "",
-      proxyUrl ? `proxy-server=${proxyUrl}` : "",
+      proxy ? `proxy-server=${proxy.url}` : "",
       ...(options?.args?.map((arg) => (arg.startsWith("--") ? arg.slice(2) : arg)) || []),
     ].filter(Boolean);
   }

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -5,12 +5,21 @@ import { SessionDetails } from "../modules/sessions/sessions.schema";
 import { v4 as uuidv4 } from "uuid";
 import { env } from "../env";
 import { BrowserLauncherOptions } from "../types";
+import { ProxyServer } from "../utils/proxy";
+
+type Session = SessionDetails & {
+  completion: Promise<void>,
+  complete: (value: void) => void,
+  proxyServer: ProxyServer | undefined,
+};
 
 const sessionStats = {
   duration: 0,
   eventCount: 0,
   timeout: 0,
   creditsUsed: 0,
+  proxyTxBytes: 0,
+  proxyRxBytes: 0,
 };
 
 const defaultSession = {
@@ -28,7 +37,7 @@ export class SessionService {
   private logger: FastifyBaseLogger;
   private cdpService: CDPService;
   private seleniumService: SeleniumService;
-  public activeSession: SessionDetails;
+  public activeSession: Session;
 
   constructor(config: { cdpService: CDPService, seleniumService: SeleniumService, logger: FastifyBaseLogger }) {
     this.cdpService = config.cdpService;
@@ -41,6 +50,7 @@ export class SessionService {
       ...sessionStats,
       completion: Promise.resolve(),
       complete: () => {},
+      proxyServer: undefined,
     }
   }
 
@@ -69,11 +79,20 @@ export class SessionService {
       blockAds,
     } = options;
 
+    if (proxyUrl) {
+      this.activeSession.proxyServer = new ProxyServer(proxyUrl);
+      this.activeSession.proxyServer.on('connectionClosed', ({ stats }) => {
+        this.activeSession.proxyTxBytes += stats.trgTxBytes;
+        this.activeSession.proxyRxBytes += stats.trgRxBytes;
+      });
+      await this.activeSession.proxyServer.listen();
+    }
+
     const browserLauncherOptions: BrowserLauncherOptions = {
       options: {
         headless: true,
         args: [userAgent ? `--user-agent=${userAgent}` : undefined].filter(Boolean) as string[],
-        proxyUrl,
+        proxyUrl: this.activeSession.proxyServer?.url,
       },
       cookies: sessionContext?.cookies || [],
       userAgent: sessionContext?.userAgent,
@@ -97,7 +116,7 @@ export class SessionService {
         userAgent:
           sessionContext?.userAgent ||
           "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
-        proxy: proxyUrl,
+        proxy: this.activeSession.proxyServer?.url,
         solveCaptcha: false,
         isSelenium,
       });
@@ -110,7 +129,7 @@ export class SessionService {
         debugUrl: `http://${env.DOMAIN ?? env.HOST}:${env.PORT}/v1/devtools/inspector.html`,
         sessionViewerUrl: `http://${env.DOMAIN ?? env.HOST}:${env.PORT}`,
         userAgent: this.cdpService.getUserAgent(),
-        proxy: proxyUrl,
+        proxy: this.activeSession.proxyServer?.url,
         solveCaptcha: false,
         isSelenium,
       });
@@ -126,6 +145,8 @@ export class SessionService {
     } else {
       await this.cdpService.endSession();
     }
+
+    await this.activeSession.proxyServer?.close(true);
 
     this.resetSessionInfo({
       ...this.activeSession,
@@ -146,6 +167,7 @@ export class SessionService {
       createdAt: new Date().toISOString(),
       completion: promise,
       complete: resolve,
+      proxyServer: undefined,
     };
 
     return this.activeSession;

--- a/api/src/utils/proxy.ts
+++ b/api/src/utils/proxy.ts
@@ -1,0 +1,29 @@
+import proxyChain from "proxy-chain";
+
+export class ProxyServer extends proxyChain.Server {
+  public url: string;
+  public upstreamProxyUrl: string;
+  public txBytes = 0;
+  public rxBytes = 0;
+
+  constructor(proxyUrl: string) {
+    super({
+      host: '127.0.0.1',
+
+      prepareRequestFunction: () => {
+        return {
+          requestAuthentication: false,
+          upstreamProxyUrl: proxyUrl,
+        };
+      },
+    });
+
+    this.on('connectionClosed', ({ stats }) => {
+      this.txBytes += stats.trgTxBytes;
+      this.rxBytes += stats.trgRxBytes;
+    });
+
+    this.url = `http://127.0.0.1:${this.port}`
+    this.upstreamProxyUrl = proxyUrl;
+  };
+}

--- a/api/src/utils/proxy.ts
+++ b/api/src/utils/proxy.ts
@@ -35,11 +35,6 @@ export class ProxyServer extends ProxyChain.Server {
     await super.listen();
     this.url = `http://127.0.0.1:${this.port}`;
   }
-
-  async close(closeConnections: boolean): Promise<void> {
-    console.debug(`Closing proxy server ${this.url} to ${this.upstreamProxyUrl}`);
-    await super.close(closeConnections);
-  }
 }
 
 const proxyReclaimRegistry = new FinalizationRegistry((heldValue: Function) => heldValue());


### PR DESCRIPTION
If proxyUrl was provided for a session, always use [proxy-chain](https://github.com/apify/proxy-chain) in front of the real proxy to meter data transferred via proxy.