### PR TITLE
feat: add CHROME_EXECUTABLE_PATH environment variable for custom chromium binaries

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,3 +1,5 @@
 NODE_ENV=
 PROXY_URL=
 DEFAULT_HEADERS=
+CHROME_EXECUTABLE_PATH=
+LOG_LEVEL=warn # fatal, error, warn, info, debug, trace

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -15,6 +15,7 @@ const envSchema = z.object({
     .transform((val) => (val ? JSON.parse(val) : {}))
     .pipe(z.record(z.string()).optional().default({})),
   KILL_TIMEOUT: z.string().optional().default("25"), // to fit in default 30 seconds of Heroku or ECS with some margin
+  CHROME_EXECUTABLE_PATH: z.string().optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/api/src/utils/browser.ts
+++ b/api/src/utils/browser.ts
@@ -1,16 +1,27 @@
-import fs from 'fs';
+import fs from "fs";
 import path from "path";
 import { Page } from "puppeteer-core";
+import { env } from "../env";
 
 export const getChromeExecutablePath = () => {
+  if (env.CHROME_EXECUTABLE_PATH) {
+    const executablePath = env.CHROME_EXECUTABLE_PATH;
+    const normalizedPath = path.normalize(executablePath);
+    if (!fs.existsSync(normalizedPath)) {
+      console.warn(`Your custom chrome executable at ${normalizedPath} does not exist`);
+    } else {
+      return executablePath;
+    }
+  }
+
   if (process.platform === "win32") {
     const programFilesPath = `${process.env["ProgramFiles"]}\\Google\\Chrome\\Application\\chrome.exe`;
     const programFilesX86Path = `C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe`;
 
     if (fs.existsSync(programFilesPath)) {
-        return programFilesPath;
+      return programFilesPath;
     } else if (fs.existsSync(programFilesX86Path)) {
-        return programFilesX86Path;
+      return programFilesX86Path;
     }
   }
 


### PR DESCRIPTION
This adds an environment variable that lets you use a custom chromium binary. For example, in `api/.env` if you have set

```env
CHROME_EXECUTABLE_PATH=/Users/QAComet/Library/Caches/ms-playwright/chromium-1148/chrome-mac/Chromium.app/Contents/MacOS/Chromium
```

you will be using Playwright's default chromium build that's cached by NPM.