### PR TITLE
fix: ensure requests made back to the API are not proxied

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -3,3 +3,4 @@ PROXY_URL=
 DEFAULT_HEADERS=
 CHROME_EXECUTABLE_PATH=
 LOG_LEVEL=warn # fatal, error, warn, info, debug, trace
+HOST=0.0.0.0 # the host of the api


### PR DESCRIPTION
This fixes issues with the recording extension not properly routing the events back to the API when using a custom proxy URL