### PR TITLE
Allow to disable fingerprinting for a session

### DIFF
--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -21,13 +21,14 @@ export const handleLaunchBrowserSession = async (
       dimensions,
       isSelenium,
       blockAds,
+      fingerprint,
     } = request.body;
 
     // If there's an active session, close it first
     await server.sessionService.endSession();
 
     return await server.sessionService.startSession({
-      sessionId, proxyUrl, userAgent, sessionContext, extensions, logSinkUrl, timezone, dimensions, isSelenium, blockAds,
+      sessionId, proxyUrl, userAgent, sessionContext, extensions, logSinkUrl, timezone, dimensions, isSelenium, blockAds, fingerprint,
     });
 
   } catch (e: unknown) {

--- a/api/src/modules/sessions/sessions.schema.ts
+++ b/api/src/modules/sessions/sessions.schema.ts
@@ -19,6 +19,7 @@ const CreateSession = z.object({
     })
     .optional()
     .describe("Dimensions to use for the session"),
+  fingerprint: z.boolean().optional().default(true).describe("Flag to indicate if fingerprinting should be enabled"),
 });
 
 const SessionDetails = z.object({
@@ -38,6 +39,7 @@ const SessionDetails = z.object({
   proxyRxBytes: z.number().int().nonnegative().describe("Amount of data received through the proxy"),
   solveCaptcha: z.boolean().optional().describe("Indicates if captcha solving is enabled"),
   isSelenium: z.boolean().optional().describe("Indicates if Selenium is used in the session"),
+  fingerprint: z.boolean().optional().describe("Indicates if fingerprinting is enabled"),
 });
 
 const ReleaseSession = SessionDetails.merge(z.object({ success: z.boolean().describe("Indicates if the session was successfully released") }));

--- a/api/src/services/cdp.service.ts
+++ b/api/src/services/cdp.service.ts
@@ -147,9 +147,11 @@ export class CDPService extends EventEmitter {
           await page.setCookie(...this.launchConfig.cookies);
         }
 
-        const fingerprintInjector = new FingerprintInjector();
-        //@ts-ignore
-        await fingerprintInjector.attachFingerprintToPuppeteer(page, this.fingerprintData!);
+        if (this.fingerprintData?.fingerprint) {
+          const fingerprintInjector = new FingerprintInjector();
+          //@ts-ignore
+          await fingerprintInjector.attachFingerprintToPuppeteer(page, this.fingerprintData);
+        }
 
         page.on("error", (err) => {
           // this.logger.error(`Page error: ${err}`);
@@ -254,10 +256,10 @@ export class CDPService extends EventEmitter {
             screenWidth: width,
             width,
             height,
-            mobile: /phone|android|mobile/i.test(this.fingerprintData!.fingerprint.navigator.userAgent),
+            mobile: /phone|android|mobile/i.test(await this.getUserAgent()),
             screenOrientation:
               height > width ? { angle: 0, type: "portraitPrimary" } : { angle: 90, type: "landscapePrimary" },
-            deviceScaleFactor: this.fingerprintData!.fingerprint.screen.devicePixelRatio,
+            deviceScaleFactor: this.fingerprintData?.fingerprint.screen.devicePixelRatio || 0,
           });
         }
 
@@ -326,21 +328,24 @@ export class CDPService extends EventEmitter {
       await this.shutdown();
     }
 
-    const { options, userAgent } = this.launchConfig;
+    const { options, userAgent, fingerprint } = this.launchConfig;
 
     const defaultExtensions = ["recorder"];
     const customExtensions = this.launchConfig.extensions ? [...this.launchConfig.extensions] : [];
 
     const extensionPaths = getExtensionPaths([...defaultExtensions, ...customExtensions]);
 
-    const fingerprintGen = new FingerprintGenerator({
-      devices: ["desktop"],
-      operatingSystems: ["linux"],
-      browsers: [{ name: "chrome", minVersion: 128 }],
-      locales: ["en-US", "en"],
-    });
+    this.fingerprintData = null;
+    if (fingerprint ?? true) {
+      const fingerprintGen = new FingerprintGenerator({
+        devices: ["desktop"],
+        operatingSystems: ["linux"],
+        browsers: [{ name: "chrome", minVersion: 128 }],
+        locales: ["en-US", "en"],
+      });
 
-    this.fingerprintData = await fingerprintGen.getFingerprint();
+      this.fingerprintData = await fingerprintGen.getFingerprint();
+    }
 
     const extensionArgs = extensionPaths.length
       ? [`--load-extension=${extensionPaths.join(",")}`, `--disable-extensions-except=${extensionPaths.join(",")}`]
@@ -443,8 +448,9 @@ export class CDPService extends EventEmitter {
     );
   }
 
-  public getUserAgent() {
-    return this.fingerprintData?.fingerprint.navigator.userAgent;
+  public async getUserAgent() {
+    const fingerprintUA = this.fingerprintData?.fingerprint.navigator.userAgent;
+    return fingerprintUA || await this.browserInstance?.userAgent() || "";
   }
 
   public async getBrowserState(): Promise<{

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -31,6 +31,7 @@ const defaultSession = {
   isSelenium: false,
   proxy: "",
   solveCaptcha: false,
+  fingerprint: true,
 };
 
 export class SessionService {
@@ -65,6 +66,7 @@ export class SessionService {
     extensions?: string[];
     timezone?: string;
     dimensions?: { width: number; height: number };
+    fingerprint?: boolean;
   }): Promise<SessionDetails> {
     const {
       sessionId,
@@ -77,6 +79,7 @@ export class SessionService {
       dimensions,
       isSelenium,
       blockAds,
+      fingerprint,
     } = options;
 
     this.resetSessionInfo({
@@ -85,6 +88,7 @@ export class SessionService {
       proxy: proxyUrl,
       solveCaptcha: false,
       isSelenium,
+      fingerprint,
     });
 
     if (proxyUrl) {
@@ -111,6 +115,7 @@ export class SessionService {
       logSinkUrl,
       timezone: timezone || "US/Pacific",
       dimensions,
+      fingerprint,
     };
 
     if (isSelenium) {
@@ -135,7 +140,7 @@ export class SessionService {
         websocketUrl: `ws://${env.DOMAIN ?? env.HOST}:${env.PORT}/`,
         debugUrl: `http://${env.DOMAIN ?? env.HOST}:${env.PORT}/v1/devtools/inspector.html`,
         sessionViewerUrl: `http://${env.DOMAIN ?? env.HOST}:${env.PORT}`,
-        userAgent: this.cdpService.getUserAgent(),
+        userAgent: await this.cdpService.getUserAgent(),
       });
     }
 

--- a/api/src/types/browser.ts
+++ b/api/src/types/browser.ts
@@ -15,6 +15,7 @@ export interface BrowserLauncherOptions {
     width: number;
     height: number;
   } | null;
+  fingerprint?: boolean;
 }
 
 export interface BrowserServerOptions {


### PR DESCRIPTION
Add a flag to sessions API to allow to opt out from fingerprinting (it stays enabled by default as now).

User agent when `fingerprint` option is either omitted or explicitly set to `true`  (a bit different every time):

    Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36

User agent when `fingerptint` option is set to `false` during session creation:

    Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/132.0.0.0 Safari/537.36