### PR TITLE
Reuse browser instance between sessions if args are the same

### DIFF
--- a/api/openapi/schemas.json
+++ b/api/openapi/schemas.json
@@ -682,7 +682,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Default Response"
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleasedSession"
+                }
+              }
+            }
           }
         }
       }
@@ -697,7 +704,14 @@
         "description": "Release browser sessions",
         "responses": {
           "200": {
-            "description": "Default Response"
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleasedSession"
+                }
+              }
+            }
           }
         }
       }

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -8,7 +8,7 @@ import {
   handleGetSessionStream,
 } from "./sessions.controller";
 import { $ref } from "../../plugins/schemas";
-import { CreateSessionRequest, RecordedEvents, SessionStreamRequest } from "./sessions.schema";
+import { CreateSessionRequest, RecordedEvents, SessionStreamRequest, ReleaseSessionRequest } from "./sessions.schema";
 import { EmitEvent } from "../../types/enums";
 
 async function routes(server: FastifyInstance) {
@@ -100,12 +100,13 @@ async function routes(server: FastifyInstance) {
         description: "Release a browser session",
         tags: ["Sessions"],
         summary: "Release a browser session",
+        // body: $ref("ReleaseSession"), // TODO: Figure out how to make body optional
         response: {
-          200: $ref("ReleaseSession"),
+          200: $ref("ReleasedSession"),
         },
       },
     },
-    async (request: FastifyRequest, reply: FastifyReply) => handleExitBrowserSession(server, request, reply),
+    async (request: ReleaseSessionRequest, reply: FastifyReply) => handleExitBrowserSession(server, request, reply),
   );
 
   server.post(
@@ -116,12 +117,13 @@ async function routes(server: FastifyInstance) {
         description: "Release browser sessions",
         tags: ["Sessions"],
         summary: "Release browser sessions",
+        // body: $ref("ReleaseSession"), // TODO: Figure out how to make body optional
         response: {
-          200: $ref("ReleaseSession"),
+          200: $ref("ReleasedSession"),
         },
       },
     },
-    async (request: FastifyRequest, reply: FastifyReply) => handleExitBrowserSession(server, request, reply),
+    async (request: ReleaseSessionRequest, reply: FastifyReply) => handleExitBrowserSession(server, request, reply),
   );
 
   server.get(

--- a/api/src/modules/sessions/sessions.schema.ts
+++ b/api/src/modules/sessions/sessions.schema.ts
@@ -48,7 +48,11 @@ const SessionDetails = z.object({
   isSelenium: z.boolean().optional().describe("Indicates if Selenium is used in the session"),
 });
 
-const ReleaseSession = SessionDetails.merge(
+const ReleaseSession = z.object({
+  forceRestart: z.boolean().optional().default(false).describe("Force restart of the browser instance (by default it will be reused if possible)"),
+}).optional();
+
+const ReleasedSession = SessionDetails.merge(
   z.object({ success: z.boolean().describe("Indicates if the session was successfully released") }),
 );
 
@@ -69,6 +73,9 @@ const MultipleSessions = z.array(SessionDetails);
 export type RecordedEvents = z.infer<typeof RecordedEvents>;
 export type CreateSessionBody = z.infer<typeof CreateSession>;
 export type CreateSessionRequest = FastifyRequest<{ Body: CreateSessionBody }>;
+
+export type ReleaseSessionBody = z.infer<typeof ReleaseSession>;
+export type ReleaseSessionRequest = FastifyRequest<{ Body: ReleaseSessionBody }>;
 export type SessionDetails = z.infer<typeof SessionDetails>;
 export type MultipleSessions = z.infer<typeof MultipleSessions>;
 
@@ -83,6 +90,7 @@ export const browserSchemas = {
   ReleaseSession,
   SessionStreamQuery,
   SessionStreamResponse,
+  ReleasedSession,
 };
 
 export default browserSchemas;


### PR DESCRIPTION
Don't restart browser instance on session start if all arguments match (except `logSinkUrl`). However, if `proxyUrl` is specified browser instance will be always re-launched because of usage of one-time proxy-chain metering proxies.

