### PR TITLE
fix: remove env requirement for local dev

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,9 +2,10 @@ import "@fontsource/inter";
 import "@radix-ui/themes/styles.css";
 import RootLayout from "@/root-layout";
 import { client } from "@/steel-client";
+import { env } from "@/env";
 
 client.setConfig({
-  baseUrl: import.meta.env.VITE_API_URL,
+  baseUrl: env.VITE_API_URL,
 });
 
 function App() {

--- a/ui/src/components/sessions/session-console/session-devtools.tsx
+++ b/ui/src/components/sessions/session-console/session-devtools.tsx
@@ -1,12 +1,11 @@
+import { env } from "@/env";
 import { useEffect, useState } from "react";
 
 export default function SessionDevTools() {
   const [pageId, setPageId] = useState<string | null>(null);
 
   useEffect(() => {
-    const ws = new WebSocket(
-      `${import.meta.env.VITE_API_URL}/v1/sessions/pageId`
-    );
+    const ws = new WebSocket(`${env.VITE_API_URL}/v1/sessions/pageId`);
 
     ws.onmessage = (event) => {
       setPageId(event.data.pageId);
@@ -28,7 +27,7 @@ export default function SessionDevTools() {
 
   return (
     <iframe
-      src={`${import.meta.env.VITE_API_URL}/v1/devtools/inspector.html${
+      src={`${env.VITE_API_URL}/v1/devtools/inspector.html${
         pageId ? `?pageId=${pageId}` : ""
       }`}
       className="w-full h-full"

--- a/ui/src/components/sessions/session-console/session-logs.tsx
+++ b/ui/src/components/sessions/session-console/session-logs.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/env";
 import { useEffect, useState, useRef } from "react";
 
 export default function SessionLogs({ id }: { id: string }) {
@@ -5,9 +6,7 @@ export default function SessionLogs({ id }: { id: string }) {
   const consoleRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const connectWebSocket = async () => {
-      const ws = new WebSocket(
-        `${import.meta.env.VITE_WS_URL}/v1/sessions/logs`
-      );
+      const ws = new WebSocket(`${env.VITE_WS_URL}/v1/sessions/logs`);
 
       ws.onmessage = (event) => {
         const logs = JSON.parse(event.data);

--- a/ui/src/components/sessions/session-viewer/session-viewer.tsx
+++ b/ui/src/components/sessions/session-viewer/session-viewer.tsx
@@ -4,6 +4,7 @@ import rrwebPlayer from "rrweb-player";
 import "./session-viewer-controls.css";
 import { LoadingSpinner } from "@/components/icons/LoadingSpinner";
 import { LiveEmptyState } from "./live-empty-state";
+import { env } from "@/env";
 
 type SessionViewerProps = {
   id: string;
@@ -98,9 +99,7 @@ export function SessionViewer({
     if (!isSessionLoading && !isSessionError) {
       if (session?.status === "live") {
         const connectWebSocket = async () => {
-          const ws = new WebSocket(
-            `${import.meta.env.VITE_WS_URL}/v1/sessions/recording`
-          );
+          const ws = new WebSocket(`${env.VITE_WS_URL}/v1/sessions/recording`);
 
           ws.onmessage = (message) => {
             const events = JSON.parse(message.data);

--- a/ui/src/env.ts
+++ b/ui/src/env.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  VITE_API_URL: z.string().default("http://0.0.0.0:3000"),
+  VITE_WS_URL: z.string().default("ws://0.0.0.0:3000"),
+  VITE_OPENAPI_URL: z
+    .string()
+    .default("http://0.0.0.0:3000/documentation/json"),
+});
+
+export const env = envSchema.parse(import.meta.env);


### PR DESCRIPTION
Many people have faced issues with running steel-browser locally because the docs didn't mention to copy over env.local.example in the `./ui` folder

This removes the need to do that in the first place