### PR TITLE
fix: use env instead of arg in dockerfile

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -2,14 +2,9 @@ FROM node:18
 
 WORKDIR /app
 # Set default values that can be overridden
-ARG VITE_API_URL=http://localhost:3000
-ARG VITE_WS_URL=ws://localhost:3000
-ARG VITE_OPENAPI_URL=http://localhost:3000/documentation/json
-
-# Make the build args available as environment variables during build
-ENV VITE_API_URL=${VITE_API_URL}
-ENV VITE_WS_URL=${VITE_WS_URL}
-ENV VITE_OPENAPI_URL=${VITE_OPENAPI_URL}
+ENV VITE_API_URL=http://localhost:3000
+ENV VITE_WS_URL=ws://localhost:3000
+ENV VITE_OPENAPI_URL=http://localhost:3000/documentation/json
 
 LABEL org.opencontainers.image.source="https://github.com/steel-dev/steel-browser"
 


### PR DESCRIPTION
# Bug

When trying to deploy the application with user modified `VITE_(API|WS|OPENAPI)_URL`, the docker containers recognised the new values, but the application would still erroneously use the url defined in the Dockerfile: `http://localhost:3000`.

## Image: sessions keeps failing due to using default localhost

![image](https://github.com/user-attachments/assets/2178b78f-f7f1-4214-9f87-00a7326b7382)

## Image: portainer showing that the docker container should have access to the correct 0.0.0.0 url

![image](https://github.com/user-attachments/assets/a4729a76-3c6a-4536-a8f5-296ded107349)


See discord thread: https://discord.com/channels/1285696350117167226/1332686819476897854/1333003206980009984

# What

Replaced the ARG with ENV. This should mean that the variable can now be correctly modified by end users during runtime.

# Notes

This should hopefully allow environment variables like VITE_API_URL to be modified afterwards by end users.

- [ ] If the substitution of `VITE_API_URL` occurs during docker build, this change might not fix the bug. Get feedback on understanding this

