### PR TITLE
Refactor Browser Path Handling

### DIFF
--- a/api/src/services/cdp.service.ts
+++ b/api/src/services/cdp.service.ts
@@ -1,7 +1,7 @@
 import puppeteer, { Browser, Page, Target, BrowserContext, Protocol } from "puppeteer-core";
 import { Duplex } from "stream";
 import { EventEmitter } from "events";
-import { getChromeExecutablePath } from "../utils/browser";
+import { getBrowserExecutablePath, BrowserType } from "../utils/browser";
 import httpProxy from "http-proxy";
 import { IncomingMessage } from "http";
 import { env } from "../env";
@@ -37,7 +37,7 @@ export class CDPService extends EventEmitter {
     this.browserInstance = null;
     this.wsEndpoint = null;
     this.fingerprintData = null;
-    this.chromeExecPath = getChromeExecutablePath();
+    this.chromeExecPath = getBrowserExecutablePath(BrowserType.CHROME);
     this.wsProxyServer = httpProxy.createProxyServer();
     this.primaryPage = null;
     this.localStorageData = {};

--- a/api/src/types/browser.ts
+++ b/api/src/types/browser.ts
@@ -34,3 +34,11 @@ export type BrowserEvent = {
   text: string;
   timestamp: Date;
 };
+
+export type Platform = "darwin" | "linux" | "win32";
+
+export interface BrowserPaths {
+  darwin: string[];
+  linux: string[];
+  win32: string[];
+}

--- a/api/src/utils/errors.ts
+++ b/api/src/utils/errors.ts
@@ -10,3 +10,24 @@ export function getErrors(e: unknown) {
 
   return error;
 }
+
+export class InvalidBrowserTypeError extends Error {
+  constructor(browserType: string) {
+    super(`Unsupported browser type: ${browserType}`);
+    this.name = "InvalidBrowserTypeError";
+  }
+}
+
+export class UnsupportedPlatformError extends Error {
+  constructor(platform: string) {
+    super(`Unsupported platform: ${platform}`);
+    this.name = "UnsupportedPlatformError";
+  }
+}
+
+export class ExecutableNotFoundError extends Error {
+  constructor(paths: string[]) {
+    super(`No valid executable found at: ${paths.join(", ")}`);
+    this.name = "ExecutableNotFoundError";
+  }
+}


### PR DESCRIPTION
## What's Changed:

- Introduced getBrowserExecutablePath as unified path resolver
- Added BrowserType enum and BrowserPaths interface for type safety
- Deprecated getChromeExecutablePath in favor of new generic resolver
- Maintained backward compatibility with Chrome-specific implementation
- Added platform validation checks

### Why This Matters:

- 🏗 Foundation for future Firefox/Edge browser integrations
- 📁 Cleaner path management with centralized configuration
- 🔍 Better error detection for missing executables

### Pending Tests

- Verify Chrome path resolution on Windows/macOS/Linux
- Ensure backward compatibility with existing implementations