### PR TITLE
Fix Xvfb & DBus Startup Issues in Docker Compose

### DIFF
--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -21,6 +21,10 @@ else
     echo "Skipping nginx startup..."
 fi
 
+### Clean up stale lock files
+echo "Cleaning up stale lock files..."
+rm -f /run/dbus/pid /tmp/.X10-lock
+
 # Create dbus directory and start daemon
 echo "Starting dbus..."
 mkdir -p /var/run/dbus


### PR DESCRIPTION
Fixes: [steel-dev/steel-browser#24](https://github.com/steel-dev/steel-browser/issues/24)

### Summary
Running docker-compose up multiple times without --force-recreate results in Xvfb and DBus failing to start due to stale lock files.

### Errors encountered:
- Failed to start message bus: The pid file "/run/dbus/pid" exists
- Fatal server error: Server is already active for display 10
- Missing X server or $DISPLAY
- Failed to connect to socket /run/dbus/system_bus_socket: Connection refused

### Root cause
- DBus and Xvfb do not clean up their lock files when Docker Compose restarts the container, leading to conflicts when trying to start them again.
- Lock files (/run/dbus/pid and /tmp/.X10-lock) persist inside mounted volumes (like .cache), even after containers are stopped.
- Entry point script does not clear these files before starting services, so they interfere on subsequent runs.

### Fix
Updated entrypoint.sh to remove stale lock files before starting DBus and Xvfb.

### To test
- Clone repository
- Rebuild with `docker-compose up --force-recreate --build`
- Exit and re-run `docker-compose up`
