### PR TITLE
Docker Local Dev Host

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ The fastest way to get started is to build and run the Docker image:
 git clone https://github.com/steel-dev/steel-browser
 cd steel-browser
 docker compose up
+
+```
+
+**Note for Local Development:** When developing locally, you may need to modify the `docker-compose.yml` environment variables to use localhost instead of the service name api. For example:
+
+```bash
+VITE_API_URL: ${VITE_API_URL:-http://localhost:3000}
+VITE_WS_URL: ${VITE_WS_URL:-ws://localhost:3000}
 ```
 
 Alternatively, if you have Node.js and Chrome installed, you can run the server directly:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,4 +35,5 @@ services:
 
 networks:
   steel-network:
+    name: steel-network
     driver: bridge


### PR DESCRIPTION
# Overview
I ran into issues while trying to run locally via Docker. I found this message [here ](https://discord.com/channels/1285696350117167226/1328008655764979773/1334540718483439759) helpful so I added a note in the Getting Started section about modifying environment variables to use localhost for local development. This helps developers avoid common connection issues when running the stack locally.

I also updated the network-name because docker pre-fixes it with the parent directory's name. This would be helpful for those who clone with custom aliases.
