### PR TITLE
Fix Puppeteer Crash: Remove --disable-software-rasterizer

### DIFF
--- a/api/src/services/cdp.service.ts
+++ b/api/src/services/cdp.service.ts
@@ -360,7 +360,6 @@ export class CDPService extends EventEmitter {
       "--disable-setuid-sandbox",
       "--use-angle=disabled",
       "--disable-blink-features=AutomationControlled",
-      "--disable-software-rasterizer",
       "--unsafely-treat-insecure-origin-as-secure=http://0.0.0.0:3000,http://localhost:3000",
       `--window-size=${this.launchConfig.dimensions?.width ?? 1920},${this.launchConfig.dimensions?.height ?? 1080}`,
       `--timezone=${timezone}`,


### PR DESCRIPTION
Fixes: https://github.com/steel-dev/steel-browser/issues/33

### Overview
Chromium was crashing due to the combination of `--disable-gpu` and `--disable-software-rasterizer`. When GPU acceleration is disabled, Chrome falls back to software rendering (SwiftShader). However, `--disable-software-rasterizer` prevents this fallback, leaving no rendering option, causing a crash in different environments. Removing this flag ensures Chromium can properly render via software when GPU is disabled.