### PR TITLE
feat: Basic playground implementation (wip)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -73,7 +73,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       unzip \
       default-jre \
       dbus \
-      dbus-x11
+      dbus-x11 \
+      python3-pip \
+      python3-venv 
+
+RUN python3 -m venv /app/venv
+ENV PATH="/app/venv/bin:$PATH"
+RUN /app/venv/bin/pip install --no-cache-dir steel-sdk python-dotenv selenium playwright
 
 # Install Chrome and ChromeDriver
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node ./build/index.js",
-    "build": "tsc && mkdir -p build/templates && cp -r src/templates/ build/templates/",
+    "build": "tsc && mkdir -p build/templates && cp -r src/templates/* build/templates/",
     "dev": "ts-node-dev --poll --exit-child ./src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "pretty": "prettier --write \"src/**/*.ts\"",

--- a/api/src/build-server.ts
+++ b/api/src/build-server.ts
@@ -9,7 +9,7 @@ import browserSessionPlugin from "./plugins/browser-session";
 import browserWebSocket from "./plugins/browser-socket/browser-socket";
 import seleniumPlugin from "./plugins/selenium";
 import customBodyParser from "./plugins/custom-body-parser";
-import { sessionsRoutes, seleniumRoutes, actionsRoutes, cdpRoutes } from "./routes";
+import { sessionsRoutes, seleniumRoutes, actionsRoutes, cdpRoutes, playgroundRoutes } from "./routes";
 import path from "path";
 
 export default function buildFastifyServer(options?: FastifyServerOptions) {
@@ -37,6 +37,7 @@ export default function buildFastifyServer(options?: FastifyServerOptions) {
   server.register(sessionsRoutes, { prefix: "/v1" });
   server.register(cdpRoutes, { prefix: "/v1" });
   server.register(seleniumRoutes);
+  server.register(playgroundRoutes, { prefix: "/v1" });
 
   return server;
 }

--- a/api/src/build-server.ts
+++ b/api/src/build-server.ts
@@ -32,6 +32,12 @@ export default function buildFastifyServer(options?: FastifyServerOptions) {
   server.register(customBodyParser);
   server.register(browserSessionPlugin);
 
+  server.addHook("onSend", (request, reply, payload, done) => {
+    reply.header("Cross-Origin-Resource-Policy", "cross-origin");
+    reply.header("Cross-Origin-Embedder-Policy", "require-corp");
+    done();
+  });
+
   // Routes
   server.register(actionsRoutes, { prefix: "/v1" });
   server.register(sessionsRoutes, { prefix: "/v1" });

--- a/api/src/modules/playground/playground.controller.ts
+++ b/api/src/modules/playground/playground.controller.ts
@@ -1,0 +1,53 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+import { spawn } from 'child_process';
+
+export async function handleRunCode(request: FastifyRequest<{ Body: { code: string } }>, reply: FastifyReply) {
+    const { code } = request.body;
+
+    if (!code) {
+        return reply.status(400).send({ error: "No code provided" });
+    }
+
+    try {
+        const result = await executePythonCode(code);
+        return reply.send(result);
+    } catch (error) {
+        if (error instanceof Error) {
+            if (error.message.includes('Timeout')) {
+                return reply.status(500).send({ error: "Execution timed out" });
+            }
+            return reply.status(500).send({ error: error.message });
+        }
+        return reply.status(500).send({ error: "Unknown error occurred" });
+    }
+}
+
+async function executePythonCode(code: string, timeout = 60000) {
+    const pythonProcess = spawn('python', ['-c', code]);
+
+    let stdout = '';
+    let stderr = '';
+    let timeoutId: NodeJS.Timeout;
+
+    pythonProcess.stdout.on('data', (data) => stdout += data);
+    pythonProcess.stderr.on('data', (data) => stderr += data);
+
+    const exitCode = await Promise.race([
+        new Promise<number>((resolve, reject) => {
+            timeoutId = setTimeout(() => {
+                pythonProcess.kill('SIGKILL');
+                reject(new Error('Timeout: Execution took too long'));
+            }, timeout);
+            pythonProcess.on('close', (code) => {
+                clearTimeout(timeoutId);
+                resolve(code || 0);
+            });
+        })
+    ]);
+
+    return {
+        result: stdout.trim(),
+        error: stderr.trim(),
+        exitCode
+    };
+}

--- a/api/src/modules/playground/playground.routes.ts
+++ b/api/src/modules/playground/playground.routes.ts
@@ -1,0 +1,48 @@
+import { FastifyInstance } from "fastify";
+import { handleRunCode } from "./playground.controller";
+
+async function routes(server: FastifyInstance) {
+    server.post(
+        "/run",
+        {
+            schema: {
+                operationId: "run_code",
+                description: "Execute python3 code",
+                tags: ["Playground"],
+                summary: "Execute python3 code",
+                body: {
+                    type: 'object',
+                    required: ['code'],
+                    properties: {
+                        code: { type: 'string' }
+                    }
+                },
+                response: {
+                    200: {
+                        type: 'object',
+                        properties: {
+                            result: { type: 'string' },
+                            error: { type: 'string' },
+                            exitCode: { type: 'number' }
+                        }
+                    },
+                    400: {
+                        type: 'object',
+                        properties: {
+                            error: { type: 'string' }
+                        }
+                    },
+                    500: {
+                        type: 'object',
+                        properties: {
+                            error: { type: 'string' }
+                        }
+                    }
+                }
+            }
+        },
+        handleRunCode
+    );
+}
+
+export default routes;

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -2,3 +2,4 @@ export { default as actionsRoutes } from "./modules/actions/actions.routes";
 export { default as sessionsRoutes } from "./modules/sessions/sessions.routes";
 export { default as seleniumRoutes } from "./modules/selenium/selenium.routes";
 export { default as cdpRoutes } from "./modules/cdp/cdp.routes";
+export { default as playgroundRoutes } from "./modules/playground/playground.routes";

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -34,7 +34,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.53.0",
-        "react-router-dom": "^6.16.0",
+        "react-router-dom": "^6.29.0",
         "react-syntax-highlighter": "^15.5.0",
         "react-top-loading-bar": "^2.3.1",
         "rrweb-player": "^1.0.0-alpha.4",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,6 +11,7 @@
         "@fontsource/inter": "^5.0.13",
         "@hey-api/client-fetch": "^0.4.0",
         "@hookform/resolvers": "^3.9.0",
+        "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-avatar": "^1.1.1",
         "@radix-ui/react-checkbox": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.2",
@@ -48,7 +49,7 @@
       },
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.53.6",
-        "@types/node": "^20.8.4",
+        "@types/node": "^20.17.17",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "@types/react-syntax-highlighter": "^15.5.8",
@@ -62,8 +63,9 @@
         "eslint-plugin-react-refresh": "^0.4.3",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.13",
-        "typescript": "^5.0.2",
-        "vite": "^4.4.5"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.7.3",
+        "vite": "^4.4.5",
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -106,6 +108,28 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -837,6 +861,30 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.4.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2264,10 +2312,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
-      "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
-      "license": "MIT",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.22.0.tgz",
+      "integrity": "sha512-MBOl8MeOzpK0HQQQshKB7pABXbmyHizdTpqnrIseTbsv0nAepwC2ENZa1aaBExNQcpLoXmWthhak8SABLzvGPw==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2570,6 +2617,30 @@
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true
     },
     "node_modules/@tsconfig/svelte": {
       "version": "1.0.13",
@@ -2931,7 +3002,7 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3744,6 +3815,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3864,6 +3941,15 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -5161,6 +5247,12 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5314,6 +5406,12 @@
         "pkg-types": "^1.2.1",
         "ufo": "^1.5.4"
       }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -6090,12 +6188,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.0.tgz",
-      "integrity": "sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==",
-      "license": "MIT",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.29.0.tgz",
+      "integrity": "sha512-DXZJoE0q+KyeVw75Ck6GkPxFak63C4fGqZGNijnWgzB/HzSP1ZfTlBj5COaGWwhrMQ/R8bXiq5Ooy4KG+ReyjQ==",
       "dependencies": {
-        "@remix-run/router": "1.21.0"
+        "@remix-run/router": "1.22.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -6105,13 +6202,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.0.tgz",
-      "integrity": "sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==",
-      "license": "MIT",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.29.0.tgz",
+      "integrity": "sha512-pkEbJPATRJ2iotK+wUwHfy0xs2T59YPEN8BQxVCPeBZvK7kfPESRc/nyxzdcxR17hXgUPYx2whMwl+eo9cUdnQ==",
       "dependencies": {
-        "@remix-run/router": "1.21.0",
-        "react-router": "6.28.0"
+        "@remix-run/router": "1.22.0",
+        "react-router": "6.29.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -6598,6 +6694,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -7077,6 +7178,55 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "devOptional": true
+    },
     "node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -7110,11 +7260,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
-      "license": "Apache-2.0",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7174,7 +7323,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -7297,6 +7446,12 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -7509,6 +7664,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -7535,6 +7710,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -26,11 +26,14 @@
         "@radix-ui/themes": "^3.0.3",
         "@tanstack/react-query": "^4.36.1",
         "@tanstack/react-table": "^8.20.5",
+        "@webcontainer/api": "^1.5.1-internal.8",
+        "@xterm/addon-fit": "^0.10.0",
         "axios": "^1.3.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "i": "^0.3.7",
         "jwt-decode": "^3.1.2",
+        "lodash-es": "^4.17.21",
         "lucide-react": "^0.447.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -45,6 +48,7 @@
         "tailwindcss-animate": "^1.0.7",
         "ua-parser-js": "^1.0.39",
         "usehooks-ts": "^3.1.0",
+        "xterm": "^5.3.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -66,6 +70,7 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.7.3",
         "vite": "^4.4.5",
+        "vite-plugin-cross-origin-isolation": "^0.1.6"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2680,11 +2685,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
-      "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
-      "dev": true,
-      "license": "MIT",
+      "version": "20.17.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.17.tgz",
+      "integrity": "sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==",
+      "devOptional": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -2976,10 +2980,29 @@
         "vite": "^4 || ^5"
       }
     },
+    "node_modules/@webcontainer/api": {
+      "version": "1.5.1-internal.8",
+      "resolved": "https://registry.npmjs.org/@webcontainer/api/-/api-1.5.1-internal.8.tgz",
+      "integrity": "sha512-EgtnRLOIFhBiTS/1nQmg3A6RtQXvp+kDK08cbEZZpnXGyaNd1y9dSCJUEn3OUCuHSEZr3LeqBtwR5mYOxFeiUQ=="
+    },
     "node_modules/@xstate/fsm": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
       "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw=="
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "peer": true
     },
     "node_modules/@zeit/schemas": {
       "version": "2.36.0",
@@ -3019,6 +3042,18 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "devOptional": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -5192,6 +5227,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -7517,6 +7557,12 @@
         }
       }
     },
+    "node_modules/vite-plugin-cross-origin-isolation": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/vite-plugin-cross-origin-isolation/-/vite-plugin-cross-origin-isolation-0.1.6.tgz",
+      "integrity": "sha512-OY0naW9nPUDrKTffYnY7FRYXOgZdHoNwMGpPxUmj/n32mGZi01fcq+J536jkmwGWX7DLT95XBQVHHbrAJzTvrw==",
+      "dev": true
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7692,6 +7738,12 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/xterm": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
+      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead."
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,7 @@
     "@fontsource/inter": "^5.0.13",
     "@hey-api/client-fetch": "^0.4.0",
     "@hookform/resolvers": "^3.9.0",
+    "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.2",
@@ -40,7 +41,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.53.0",
-    "react-router-dom": "^6.16.0",
+    "react-router-dom": "^6.29.0",
     "react-syntax-highlighter": "^15.5.0",
     "react-top-loading-bar": "^2.3.1",
     "styled-components": "^6.0.8",
@@ -52,7 +53,7 @@
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.53.6",
-    "@types/node": "^20.8.4",
+    "@types/node": "^20.17.17",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@types/react-syntax-highlighter": "^15.5.8",
@@ -66,7 +67,8 @@
     "eslint-plugin-react-refresh": "^0.4.3",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
-    "typescript": "^5.0.2",
-    "vite": "^4.4.5"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.3",
+    "vite": "^4.4.5",
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "start": "serve dist -l 5173",
+    "start": "serve dist -l 5173 --single --config serve.json",
     "dev": "vite --host 0.0.0.0",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
@@ -12,7 +12,6 @@
     "generate-api": "openapi-ts"
   },
   "dependencies": {
-    "serve": "^14.0.1",
     "@fontsource/inter": "^5.0.13",
     "@hey-api/client-fetch": "^0.4.0",
     "@hookform/resolvers": "^3.9.0",
@@ -31,11 +30,14 @@
     "@radix-ui/themes": "^3.0.3",
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-table": "^8.20.5",
+    "@webcontainer/api": "^1.5.1-internal.8",
+    "@xterm/addon-fit": "^0.10.0",
     "axios": "^1.3.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "i": "^0.3.7",
     "jwt-decode": "^3.1.2",
+    "lodash-es": "^4.17.21",
     "lucide-react": "^0.447.0",
     "rrweb-player": "^1.0.0-alpha.4",
     "react": "^18.2.0",
@@ -44,11 +46,13 @@
     "react-router-dom": "^6.29.0",
     "react-syntax-highlighter": "^15.5.0",
     "react-top-loading-bar": "^2.3.1",
+    "serve": "^14.0.1",
     "styled-components": "^6.0.8",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "ua-parser-js": "^1.0.39",
     "usehooks-ts": "^3.1.0",
+    "xterm": "^5.3.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -70,5 +74,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3",
     "vite": "^4.4.5",
+    "vite-plugin-cross-origin-isolation": "^0.1.6"
   }
 }

--- a/ui/public/serve.json
+++ b/ui/public/serve.json
@@ -1,0 +1,17 @@
+{
+  "headers": [
+    {
+      "source": "**/*",
+      "headers": [
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        }
+      ]
+    }
+  ]
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,15 +1,27 @@
 import "@fontsource/inter";
 import "@radix-ui/themes/styles.css";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import RootLayout from "@/root-layout";
 import { client } from "@/steel-client";
 import { env } from "@/env";
+import { HomePage } from "./pages/home-page";
+import { PlaygroundPage } from "./pages/playground-page";
 
 client.setConfig({
   baseUrl: env.VITE_API_URL,
 });
 
 function App() {
-  return <RootLayout />;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route element={<RootLayout />}>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/playground" element={<PlaygroundPage />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -3,6 +3,7 @@ import { Badge } from "@/components/ui/badge";
 import { GlowingGreenDot } from "@/components/icons/GlowingGreenDot";
 import { useSessionsContext } from "@/hooks/use-sessions-context";
 import { SteelIcon } from "../icons/SessionIcon";
+import { Link } from "react-router-dom";
 
 export const Header = () => {
   const { pathname } = window.location;
@@ -53,6 +54,12 @@ export const Header = () => {
       </div>
       <nav className="flex-1 flex justify-end">
         <div className="flex gap-2 items-center">
+          <Link
+            to="/playground"
+            className="rounded-md opacity-90 bg-transparent flex h-10 px-4 justify-center items-center gap-3 text-primary hover:bg-[rgba(238,206,254,0.13)] font-inter text-base font-normal leading-6 cursor-pointer"
+          >
+            Playground
+          </Link>
           <a
             href="https://docs.steel.dev"
             target="_blank"

--- a/ui/src/components/playground/CodeEditor.tsx
+++ b/ui/src/components/playground/CodeEditor.tsx
@@ -1,0 +1,46 @@
+import { Editor } from '@monaco-editor/react';
+import type { editor } from 'monaco-editor';
+import type { Language } from '@/types/language';
+
+interface CodeEditorProps {
+    language: Language;
+    code: string;
+    onEditorChange: (value?: string) => void;
+    onEditorMount: (editor: editor.IStandaloneCodeEditor) => void;
+}
+
+export function CodeEditor({
+    language,
+    code,
+    onEditorChange,
+    onEditorMount
+}: CodeEditorProps) {
+    function beforeMount(monaco: typeof import('monaco-editor')) {
+        const defaultOptions = monaco.languages.typescript.typescriptDefaults.getCompilerOptions();
+        monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+            ...defaultOptions,
+            allowJs: true,
+        });
+    }
+    return (
+        <Editor
+            beforeMount={beforeMount}
+            theme="vs-dark"
+            height="60vh"
+            width="100%"
+            language={language}
+            value={code}
+            onChange={onEditorChange}
+            onMount={onEditorMount}
+            options={{
+                minimap: { enabled: false },
+                fontSize: 16,
+                lineNumbers: 'on',
+                roundedSelection: false,
+                scrollBeyondLastLine: false,
+                automaticLayout: true,
+            }}
+
+        />
+    );
+}

--- a/ui/src/components/playground/LanguageSelector.tsx
+++ b/ui/src/components/playground/LanguageSelector.tsx
@@ -1,0 +1,24 @@
+import type { Language } from '@/types/language';
+
+interface LanguageSelectorProps {
+    selectedLanguage: Language;
+    onLanguageChange: (lang: Language) => void;
+    className?: string;
+}
+
+export function LanguageSelector({
+    selectedLanguage,
+    onLanguageChange,
+    className
+}: LanguageSelectorProps) {
+    return (
+        <select
+            value={selectedLanguage}
+            onChange={(e) => onLanguageChange(e.target.value as Language)}
+            className={className}
+        >
+            <option value="python">Python</option>
+            <option value="typescript">TypeScript</option>
+        </select>
+    );
+}

--- a/ui/src/components/playground/PythonResult.tsx
+++ b/ui/src/components/playground/PythonResult.tsx
@@ -1,0 +1,62 @@
+interface PythonResultProps {
+    result?: string;
+    error?: string;
+    exitCode?: number;
+    isError: boolean;
+}
+
+export function PythonResult({ result, error, exitCode, isError }: PythonResultProps) {
+    // Show default state before any execution
+    if (exitCode === undefined) {
+        return (
+            <div className="p-4 rounded-lg overflow-hidden bg-[var(--gray-3)] border border-gray-300 dark:border-gray-600 max-h-[23vh] flex flex-col">
+                <div className="flex-1 flex items-center justify-center text-gray-500 italic">
+                    Run Python code to see the output here.
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className={`p-3 rounded-lg overflow-hidden ${exitCode === 0
+            ? 'bg-green-100 dark:bg-[var(--gray-3)] border border-green-400 dark:border-gray-600'
+            : 'bg-red-100 dark:bg-[var(--gray-3)] border border-red-400 dark:border-gray-600'
+            } max-h-[22vh] flex flex-col`}
+        >
+            <div className="flex justify-between items-center mb-2 shrink-0">
+                <span className={`font-semibold ${exitCode === 0
+                    ? 'text-green-500'
+                    : 'text-red-500'
+                    }`}>
+                    {exitCode === 0 ? '✅ Execution Successful' : '❌ Execution Failed'}
+                </span>
+                <span className={`text-sm px-2 py-1 rounded ${exitCode === 0
+                    ? 'bg-green-200 text-green-800'
+                    : 'bg-red-200 text-red-800'
+                    }`}>
+                    Exit Code: {exitCode ?? 'N/A'}
+                </span>
+            </div>
+
+            <div className="flex-1 overflow-y-auto space-y-2">
+                {result && (
+                    <pre className="whitespace-pre-wrap text-sm p-3 rounded bg-white/80 backdrop-blur-sm overflow-x-auto text-green-900">
+                        {result}
+                    </pre>
+                )}
+
+                {error && (
+                    <pre className="whitespace-pre-wrap text-sm p-3 rounded bg-white/80 backdrop-blur-sm overflow-x-auto text-red-900">
+                        {error}
+                    </pre>
+                )}
+
+                {isError && (
+                    <div className="text-red-800">
+                        An error occurred during execution.
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/ui/src/components/playground/TerminalComponent.tsx
+++ b/ui/src/components/playground/TerminalComponent.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react';
+import { Terminal } from 'xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import type { WebContainerProcess } from '@webcontainer/api';
+import 'xterm/css/xterm.css';
+
+interface TerminalComponentProps {
+    containerRef: React.RefObject<HTMLDivElement>;
+    shellProcess: WebContainerProcess | null;
+}
+
+export function TerminalComponent({
+    containerRef,
+    shellProcess
+}: TerminalComponentProps) {
+    const terminalRef = useRef<Terminal | null>(null);
+    const fitAddonRef = useRef<FitAddon | null>(null);
+    const writerRef = useRef<WritableStreamDefaultWriter | null>(null);
+
+    useEffect(() => {
+        if (!containerRef.current || !shellProcess) return;
+
+        const term = new Terminal();
+        const fitAddon = new FitAddon();
+
+        term.loadAddon(fitAddon);
+        term.open(containerRef.current);
+        fitAddon.fit();
+
+        terminalRef.current = term;
+        fitAddonRef.current = fitAddon;
+
+        writerRef.current = shellProcess.input.getWriter();
+
+        shellProcess.output.pipeTo(new WritableStream({
+            write(data) { term.write(data) }
+        }));
+
+        term.onData(data => {
+            if (writerRef.current) {
+                writerRef.current.write(data);
+            }
+        });
+
+        const handleResize = () => fitAddon.fit();
+        window.addEventListener('resize', handleResize);
+
+        return () => {
+            window.removeEventListener('resize', handleResize);
+            term.dispose();
+
+            if (writerRef.current) {
+                writerRef.current.releaseLock();
+                writerRef.current = null;
+            }
+        };
+    }, [shellProcess, containerRef]);
+
+    return null;
+}

--- a/ui/src/hooks/use-file-sync.ts
+++ b/ui/src/hooks/use-file-sync.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { debounce } from 'lodash-es';
+import type { WebContainer } from '@webcontainer/api';
+
+export function useFileSync(
+    webContainer: WebContainer | null,
+    filePath: string,
+    content: string
+) {
+    useEffect(() => {
+        if (!webContainer) return;
+
+        const writeFile = debounce(async (code: string) => {
+            try {
+                await webContainer.fs.writeFile(filePath, code);
+                console.log('File updated:', filePath);
+            } catch (error) {
+                console.error('Error writing file:', error);
+            }
+        }, 500);
+
+        writeFile(content);
+
+        return () => writeFile.cancel();
+    }, [content, webContainer, filePath]);
+}

--- a/ui/src/hooks/use-web-container.ts
+++ b/ui/src/hooks/use-web-container.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { WebContainer } from '@webcontainer/api';
+import type { WebContainerProcess, FileSystemTree } from '@webcontainer/api';
+
+export function useWebContainer(initialFiles: FileSystemTree) {
+    const [webContainer, setWebContainer] = useState<WebContainer | null>(null);
+    const [shellProcess, setShellProcess] = useState<WebContainerProcess | null>(null);
+
+    useEffect(() => {
+        let mounted = true;
+
+        const init = async () => {
+            try {
+                const wc = await WebContainer.boot();
+                await wc.mount(initialFiles);
+                const sp = await wc.spawn('bash');
+                if (mounted) {
+                    setWebContainer(wc);
+                    setShellProcess(sp);
+                }
+            } catch (error) {
+                console.error('WebContainer initialization failed:', error);
+            }
+        };
+
+        init();
+        return () => {
+            mounted = false;
+            webContainer?.teardown();
+            shellProcess?.kill();
+        };
+    }, []);
+
+    return { webContainer, shellProcess };
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -163,6 +163,7 @@ h6 {
   html {
     font-family: "Geist", sans-serif;
   }
+
   :root {
     --base-1: 0 0% 98.82352941176471%;
     --base-2: 0 0% 97.6470588235294%;
@@ -203,13 +204,13 @@ h6 {
     --accent: 226.2111801242236 65.18218623481782% 51.5686274509804%;
     --accent-foreground: 0 0% 100%;
     --destructive: 10.10869565217391 73.01587301587303% 50.588235294117645%;
-    --destructive-foreground: 7.868852459016397 49.59349593495935%
-      24.11764705882353%;
+    --destructive-foreground: 7.868852459016397 49.59349593495935% 24.11764705882353%;
     --border: 0 0% 85.09803921568627%;
     --input: 0 0% 85.09803921568627%;
     --ring: 0 0% 85.09803921568627%;
     --radius: 0.5rem;
   }
+
   .dark {
     --base-1: 0 0% 6.666666666666667%;
     --base-2: 0 0% 9.803921568627452%;
@@ -256,4 +257,23 @@ h6 {
     --ring: 0 0% 22.745098039215687%;
     --radius: 0.5rem;
   }
+}
+
+.xterm-viewport::-webkit-scrollbar {
+  width: 10px;
+}
+
+.xterm-viewport::-webkit-scrollbar-track {
+  background: #1e1e1e;
+}
+
+.xterm-viewport::-webkit-scrollbar-thumb {
+  background-color: #555;
+  border-radius: 10px;
+  border: 2px solid #1e1e1e;
+}
+
+.xterm-viewport {
+  scrollbar-width: thin;
+  scrollbar-color: #555 #1e1e1e;
 }

--- a/ui/src/pages/home-page.tsx
+++ b/ui/src/pages/home-page.tsx
@@ -1,0 +1,5 @@
+import { SessionContainer } from "../containers/session-container";
+
+export function HomePage() {
+    return <SessionContainer />;
+}

--- a/ui/src/pages/playground-page.tsx
+++ b/ui/src/pages/playground-page.tsx
@@ -10,6 +10,7 @@ import { INITIAL_FILES } from '../utils/constants';
 import { Language } from '@/types/language';
 import { editor } from 'monaco-editor';
 import { env } from '@/env';
+import { useSessionsContext } from '@/hooks/use-sessions-context';
 import { PlayIcon } from '@radix-ui/react-icons';
 
 interface PythonExecutionResult {
@@ -19,6 +20,9 @@ interface PythonExecutionResult {
 }
 
 export function PlaygroundPage() {
+    const { useSession } = useSessionsContext();
+    const { data: session } = useSession("");
+
     const [selectedLanguage, setSelectedLanguage] = useState<Language>(Language.TypeScript);
     const [codeContent, setCodeContent] = useState({
         python: INITIAL_FILES['main.py'].file.contents,
@@ -42,6 +46,7 @@ export function PlaygroundPage() {
             return response.json();
         },
     });
+
     useFileSync(webContainer, currentFilePath, codeContent[selectedLanguage]);
 
     useEffect(() => {
@@ -107,6 +112,7 @@ export function PlaygroundPage() {
                                 containerRef={terminalContainerRef}
                                 shellProcess={shellProcess}
                             />
+                        </div>
                     ) : (
                         <PythonResult
                             result={runPythonMutation.data?.result}
@@ -116,6 +122,12 @@ export function PlaygroundPage() {
                         />
                     )}
                 </div>
+                <div className="p-4 flex flex-col gap-4 w-[50vw] border-t border-gray-600">
+                    <iframe
+                        src={session?.debugUrl}
+                        className="w-full h-[120vh] border-0"
+                    ></iframe>
+                    <small className="text-xs text-gray-500">Session ID: {session?.id}</small>
                 </div>
             </div>
         </div>

--- a/ui/src/pages/playground-page.tsx
+++ b/ui/src/pages/playground-page.tsx
@@ -1,4 +1,23 @@
+import { LanguageSelector } from '../components/playground/LanguageSelector';
+import { CodeEditor } from '../components/playground/CodeEditor';
+import { Language } from '@/types/language';
+import { editor } from 'monaco-editor';
 export function PlaygroundPage() {
+    const [selectedLanguage, setSelectedLanguage] = useState<Language>(Language.TypeScript);
+    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
     return (
+        <div>
+                <LanguageSelector
+                    selectedLanguage={selectedLanguage}
+                    onLanguageChange={setSelectedLanguage}
+                    className='inline-flex items-center justify-center whitespace-nowrap text-sm font-medium disabled:opacity-50 shadow-sm hover:bg-secondary/80 h-9 py-2 text-primary bg-[var(--gray-3)] px-3 transition-colors focus:outline-none'
+                />
+                <div className="p-4 flex flex-col gap-4 w-[50vw] h-[90vh] border-t border-gray-600">
+                    <CodeEditor
+                        language={selectedLanguage}
+                        onEditorMount={(editor) => editorRef.current = editor}
+                    />
+            </div>
+        </div>
     );
 }

--- a/ui/src/pages/playground-page.tsx
+++ b/ui/src/pages/playground-page.tsx
@@ -1,22 +1,69 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import { LanguageSelector } from '../components/playground/LanguageSelector';
 import { CodeEditor } from '../components/playground/CodeEditor';
+import { TerminalComponent } from '../components/playground/TerminalComponent';
+import { useWebContainer } from '@/hooks/use-web-container';
+import { useFileSync } from '@/hooks/use-file-sync';
+import { INITIAL_FILES } from '../utils/constants';
 import { Language } from '@/types/language';
 import { editor } from 'monaco-editor';
 export function PlaygroundPage() {
     const [selectedLanguage, setSelectedLanguage] = useState<Language>(Language.TypeScript);
+    const [codeContent, setCodeContent] = useState({
+        python: INITIAL_FILES['main.py'].file.contents,
+        typescript: INITIAL_FILES['index.ts'].file.contents
+    });
+
     const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+    const terminalContainerRef = useRef<HTMLDivElement>(null);
+
+    const { webContainer, shellProcess } = useWebContainer(INITIAL_FILES);
+    const currentFilePath = selectedLanguage === Language.TypeScript ? '/index.ts' : '/main.py';
+    useFileSync(webContainer, currentFilePath, codeContent[selectedLanguage]);
+
+    useEffect(() => {
+        const loadInitialFile = async () => {
+            if (!webContainer) return;
+            try {
+                const content = await webContainer.fs.readFile(currentFilePath, 'utf-8');
+                setCodeContent(prev => ({ ...prev, [selectedLanguage]: content }));
+            } catch (error) {
+                console.log('File not found, using default content');
+            }
+        };
+        loadInitialFile();
+    }, [webContainer, currentFilePath, selectedLanguage]);
+
+    const handleEditorChange = useCallback((value?: string) => {
+        setCodeContent(prev => ({ ...prev, [selectedLanguage]: value || '' }));
+    }, [selectedLanguage]);
+
     return (
         <div>
+            <div className="flex gap-4 space-between px-4">
                 <LanguageSelector
                     selectedLanguage={selectedLanguage}
                     onLanguageChange={setSelectedLanguage}
                     className='inline-flex items-center justify-center whitespace-nowrap text-sm font-medium disabled:opacity-50 shadow-sm hover:bg-secondary/80 h-9 py-2 text-primary bg-[var(--gray-3)] px-3 transition-colors focus:outline-none'
                 />
+            </div>
+            <div className="flex">
                 <div className="p-4 flex flex-col gap-4 w-[50vw] h-[90vh] border-t border-gray-600">
                     <CodeEditor
                         language={selectedLanguage}
+                        code={codeContent[selectedLanguage]}
+                        onEditorChange={handleEditorChange}
                         onEditorMount={(editor) => editorRef.current = editor}
                     />
+                        <div>
+                            <div className="w-full max-h-[23vh] rounded-lg" ref={terminalContainerRef} />
+                            <TerminalComponent
+                                containerRef={terminalContainerRef}
+                                shellProcess={shellProcess}
+                            />
+                </div>
+                </div>
             </div>
         </div>
     );

--- a/ui/src/pages/playground-page.tsx
+++ b/ui/src/pages/playground-page.tsx
@@ -12,6 +12,7 @@ import { editor } from 'monaco-editor';
 import { env } from '@/env';
 import { useSessionsContext } from '@/hooks/use-sessions-context';
 import { PlayIcon } from '@radix-ui/react-icons';
+import SessionLogs from '@/components/sessions/session-console/session-logs';
 
 interface PythonExecutionResult {
     result: string;
@@ -128,6 +129,7 @@ export function PlaygroundPage() {
                         className="w-full h-[120vh] border-0"
                     ></iframe>
                     <small className="text-xs text-gray-500">Session ID: {session?.id}</small>
+                    <SessionLogs id={session?.id!} />
                 </div>
             </div>
         </div>

--- a/ui/src/pages/playground-page.tsx
+++ b/ui/src/pages/playground-page.tsx
@@ -1,0 +1,4 @@
+export function PlaygroundPage() {
+    return (
+    );
+}

--- a/ui/src/root-layout.tsx
+++ b/ui/src/root-layout.tsx
@@ -2,9 +2,9 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { SessionsProvider } from "./contexts/sessions-context";
 import { queryClient } from "./lib/query-client";
-import { SessionContainer } from "./containers/session-container";
 import { Header } from "@/components/header";
 import { Toaster } from "@/components/ui/toaster";
+import { Outlet } from "react-router-dom";
 
 export default function RootLayout() {
   return (
@@ -14,7 +14,7 @@ export default function RootLayout() {
           <div className="flex flex-col h-screen overflow-hidden max-h-screen items-center justify-center flex-1 bg-secondary text-primary-foreground">
             <Header />
             <div className="flex flex-col overflow-hidden flex-1 w-full">
-              <SessionContainer />
+              <Outlet />
             </div>
           </div>
           <Toaster />

--- a/ui/src/types/language.ts
+++ b/ui/src/types/language.ts
@@ -1,0 +1,4 @@
+export enum Language {
+    TypeScript = "typescript",
+    Python = "python"
+}

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -1,0 +1,269 @@
+export const INITIAL_FILES = {
+    'index.ts': {
+        file: {
+            contents: `// run the following commands in the terminal
+// 1. \`export STEEL_API_KEY=your_api_key_here\`
+// 2. \`npm start\`
+
+import puppeteer from "puppeteer";
+import Steel from "steel-sdk";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const STEEL_API_KEY = process.env.STEEL_API_KEY;
+// Initialize Steel client with the API key from environment variables
+const client = new Steel({
+steelAPIKey: STEEL_API_KEY,
+});
+
+async function main() {
+let session;
+let browser;
+
+try {
+console.log("Creating Steel session...");
+
+// Create a new Steel session with all available options
+session = await client.sessions.create({
+// === Basic Options ===
+// useProxy: true, // Use Steel's proxy network (residential IPs)
+// proxyUrl: 'http://...',         // Use your own proxy (format: protocol://username:password@host:port)
+// solveCaptcha: true,             // Enable automatic CAPTCHA solving
+// sessionTimeout: 1800000,        // Session timeout in ms (default: 15 mins, max: 60 mins)
+// === Browser Configuration ===
+// userAgent: 'custom-ua-string',  // Set a custom User-Agent
+});
+
+console.log(\`Session created successfully with Session ID: \${session.id}.
+You can view the session live at \${session.sessionViewerUrl}
+\`);
+
+// Connect Puppeteer to the Steel session
+browser = await puppeteer.connect({
+browserWSEndpoint: \`wss://connect.steel.dev?apiKey=\${STEEL_API_KEY}&sessionId=\${session.id}\`,
+});
+
+console.log("Connected to browser via Puppeteer");
+
+// Create a new page
+const page = await browser.newPage();
+
+// ============================================================
+// Your Automations Go Here!
+// ============================================================
+
+// Example script - Navigate to Hacker News and extract the top 5 stories (you can delete this)
+// Navigate to Hacker News
+console.log("Navigating to Hacker News...");
+await page.goto("https://news.ycombinator.com", {
+waitUntil: "networkidle0",
+});
+
+// Extract the top 5 stories
+const stories = await page.evaluate(() => {
+const items = [];
+// Get all story items
+const storyRows = document.querySelectorAll("tr.athing");
+
+// Loop through first 5 stories
+for (let i = 0; i < 5; i++) {
+const row = storyRows[i];
+const titleElement = row.querySelector(".titleline > a");
+const subtext = row.nextElementSibling;
+const score = subtext?.querySelector(".score");
+
+items.push({
+title: titleElement?.textContent || "",
+link: titleElement?.getAttribute("href") || "",
+points: score?.textContent?.split(" ")[0] || "0",
+});
+}
+return items;
+});
+
+// Print the results
+console.log("\\nTop 5 Hacker News Stories:");
+stories.forEach((story, index) => {
+console.log(\`\\n\${index + 1}. \${story.title}\`);
+console.log(\`   Link: \${story.link}\`);
+console.log(\`   Points: \${story.points}\`);
+});
+
+// ============================================================
+// End of Automations
+// ============================================================
+} catch (error) {
+console.error("An error occurred:", error);
+} finally {
+// Cleanup: Gracefully close browser and release session when done (even when an error occurs)
+if (browser) {
+await browser.close();
+console.log("Browser closed");
+}
+
+if (session) {
+console.log("Releasing session...");
+await client.sessions.release(session.id);
+console.log("Session released");
+}
+
+console.log("Done!");
+}
+}
+
+// Run the script
+main();
+            `
+        }
+    },
+    'package.json': {
+        file: {
+            contents: `{
+"name": "steel-puppeteer-starter",
+"version": "1.0.0",
+"description": "A starter project for using Puppeteer with Steel on Node.js & TypeScript",
+"main": "index.ts",
+"scripts": {
+"test": "echo \\"Error: no test specified\\" && exit 1",
+"start": "ts-node index.ts"
+},
+"keywords": [],
+"author": "",
+"license": "ISC",
+"dependencies": {
+"@types/node": "^22.9.0",
+"dotenv": "^16.4.5",
+"puppeteer": "^23.8.0",
+"steel-sdk": "^0.1.0-beta.2",
+"typescript": "^5.6.3",
+"uuid": "^11.0.3"
+},
+"devDependencies": {
+"ts-node": "^10.9.2"
+}
+}`}
+    },
+    'tsconfig.json': {
+        file: {
+            contents: `{
+"compilerOptions": {
+"target": "es2016",
+"module": "commonjs",
+"esModuleInterop": true,
+"forceConsistentCasingInFileNames": true,
+"strict": true,
+"skipLibCheck": true,
+"lib": ["ES2016", "DOM"]
+}
+}`}
+    },
+    'main.py': {
+        file: {
+            contents: `import os
+from typing import Optional
+from dotenv import load_dotenv
+from playwright.sync_api import sync_playwright
+from steel import Steel
+import time 
+
+# Load environment variables from .env file
+load_dotenv()
+
+STEEL_API_KEY = "hello"
+
+# Initialize Steel client with the API key from environment variables
+client = Steel(steel_api_key=STEEL_API_KEY, base_url="http://localhost:3000")
+
+
+def main():
+    session = None
+    browser = None
+
+    try:
+        print("Creating Steel session...")
+
+        # Create a new Steel session with all available options
+        session = client.sessions.create(
+            session_id="026a843c-9d90-446a-ae1f-78fd9107acab"
+            # === Basic Options ===
+            # use_proxy=True,              # Use Steel's proxy network (residential IPs)
+            # proxy_url='http://...',      # Use your own proxy (format: protocol://username:password@host:port)
+            # solve_captcha=True,          # Enable automatic CAPTCHA solving
+            # session_timeout=1800000,     # Session timeout in ms (default: 15 mins, max: 60 mins)
+            # === Browser Configuration ===
+            # user_agent='custom-ua',      # Set a custom User-Agent
+        )
+
+        print(f"""Session created successfully with Session ID: {session.id}.
+You can view the session live at {session.session_viewer_url}
+        """)
+
+        # Connect Playwright to the Steel session
+        playwright = sync_playwright().start()
+        browser = playwright.chromium.connect_over_cdp(
+            f"ws://localhost:3000?apiKey={STEEL_API_KEY}&sessionId={session.id}"
+        )
+
+        print("Connected to browser via Playwright")
+
+        # Create page at existing context to ensure session is recorded.
+        currentContext = browser.contexts[0]
+        page = currentContext.new_page()
+
+        # ============================================================
+        # Your Automations Go Here!
+        # ============================================================
+
+        # Example script - Navigate to Hacker News and extract the top 5 stories
+        print("Navigating to Hacker News...")
+        page.goto("https://news.ycombinator.com", wait_until="networkidle")
+        time.sleep(3)
+        # Find all story rows
+        story_rows = page.locator("tr.athing").all()[:5]  # Get first 5 stories
+
+        # Extract the top 5 stories using Playwright's locators
+        print("\\nTop 5 Hacker News Stories:")
+        for i, row in enumerate(story_rows, 1):
+            # Get the title and link from the story row
+            title_element = row.locator(".titleline > a")
+            title = title_element.text_content()
+            link = title_element.get_attribute("href")
+
+            # Get points from the following row
+            points_element = row.locator(
+                "xpath=following-sibling::tr[1]").locator(".score")
+            points = points_element.text_content().split(
+            )[0] if points_element.count() > 0 else "0"
+
+            # Print the story details
+            print(f"\\n{i}. {title}")
+            print(f"   Link: {link}")
+            print(f"   Points: {points}")
+
+        # ============================================================
+        # End of Automations
+        # ============================================================
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+    finally:
+        # Cleanup: Gracefully close browser and release session when done
+        if browser:
+            browser.close()
+            print("Browser closed")
+
+        if session:
+            print("Releasing session...")
+            client.sessions.release(session.id)
+            print("Session released")
+
+        print("Done!")
+
+
+# Run the script
+if __name__ == "__main__":
+    main()`
+        }
+    }
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import crossOriginIsolation from 'vite-plugin-cross-origin-isolation'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), crossOriginIsolation()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
Basic playground implementation with support for typescript and python code. 

This uses webcontainers to run typescript playground code, probably will want to move off that as it cannot access local endpoints.

also, a server hook has been added to embed the  #iframe as it wasn't working by default.

api/src/build-server.ts
```
server.addHook("onSend", (request, reply, payload, done) => {
    reply.header("Cross-Origin-Resource-Policy", "cross-origin");
    reply.header("Cross-Origin-Embedder-Policy", "require-corp");
    done();
  });
```