### PR TITLE
fix: remove extra session restart call and rename pending to idle

### DIFF
--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -23,9 +23,6 @@ export const handleLaunchBrowserSession = async (
       blockAds,
     } = request.body;
 
-    // If there's an active session, close it first
-    await server.sessionService.endSession();
-
     return await server.sessionService.startSession({
       sessionId,
       proxyUrl,

--- a/api/src/modules/sessions/sessions.schema.ts
+++ b/api/src/modules/sessions/sessions.schema.ts
@@ -49,7 +49,7 @@ const CreateSession = z.object({
 const SessionDetails = z.object({
   id: z.string().uuid().describe("Unique identifier for the session"),
   createdAt: z.string().datetime().describe("Timestamp when the session started"),
-  status: z.enum(["pending", "live", "released", "failed"]).describe("Status of the session"),
+  status: z.enum(["idle", "live", "released", "failed"]).describe("Status of the session"),
   duration: z.number().int().describe("Duration of the session in milliseconds"),
   eventCount: z.number().int().describe("Number of events processed in the session"),
   dimensions: z


### PR DESCRIPTION
An extra session restart call was causing launch times to nearly double -- refactored some of the session logic such that launching a new session doesn't duplicate the work