### PR TITLE
feat: reuse idle browser when config is unchanged

### DIFF
--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import { env } from "../env";
 import { BrowserLauncherOptions } from "../types";
 import { ProxyServer } from "../utils/proxy";
-import { Protocol } from "devtools-protocol";
+import { CookieData } from "puppeteer-core";
 
 type Session = SessionDetails & {
   completion: Promise<void>;
@@ -62,7 +62,7 @@ export class SessionService {
     proxyUrl?: string;
     userAgent?: string;
     sessionContext?: {
-      cookies?: Protocol.Network.CookieParam[];
+      cookies?: CookieData[];
       localStorage?: Record<string, Record<string, any>>;
     };
     isSelenium?: boolean;
@@ -84,7 +84,7 @@ export class SessionService {
       isSelenium,
       blockAds,
     } = options;
-    
+
     await this.resetSessionInfo({
       id: sessionId || uuidv4(),
       status: "live",
@@ -111,12 +111,12 @@ export class SessionService {
         args: [userAgent ? `--user-agent=${userAgent}` : undefined].filter(Boolean) as string[],
         proxyUrl: this.activeSession.proxyServer?.url,
       },
-      sessionContext: options.sessionContext,
+      sessionContext,
       userAgent,
       blockAds,
       extensions: extensions || [],
       logSinkUrl,
-      timezone: timezone || "US/Pacific",
+      timezone,
       dimensions,
     };
 
@@ -160,12 +160,12 @@ export class SessionService {
     }
 
     const releasedSession = this.activeSession;
-    
+
     await this.resetSessionInfo({
       id: uuidv4(),
       status: "idle",
     });
-    
+
     return releasedSession;
   }
 

--- a/api/src/types/browser.ts
+++ b/api/src/types/browser.ts
@@ -1,4 +1,4 @@
-import { Protocol } from "puppeteer-core";
+import { CookieData } from "puppeteer-core";
 import { BrowserEventType } from "./enums";
 
 export interface BrowserLauncherOptions {
@@ -6,7 +6,7 @@ export interface BrowserLauncherOptions {
   req?: Request;
   stealth?: boolean;
   sessionContext?: {
-    cookies?: Protocol.Network.CookieParam[];
+    cookies?: CookieData[];
     localStorage?: Record<string, Record<string, any>>;
   };
   userAgent?: string;


### PR DESCRIPTION
This pull request includes several changes to the `CDPService` and `SessionService` classes, as well as updates to the `BrowserLauncherOptions` interface. The main focus is on improving the handling of browser sessions, configuration, and cookie data.

### Improvements to `CDPService`:

* Removed the `isActive` property and replaced it with more detailed session state management, including `localStorageData`, `fingerprintData`, and `currentSessionConfig` reset on shutdown. [[1]](diffhunk://#diff-f92e758934f17be597c0b9471e00bc520dd55b111d99d2435355ca3d37a71a11L18-R18) [[2]](diffhunk://#diff-f92e758934f17be597c0b9471e00bc520dd55b111d99d2435355ca3d37a71a11L35-R35) [[3]](diffhunk://#diff-f92e758934f17be597c0b9471e00bc520dd55b111d99d2435355ca3d37a71a11L382-R386) [[4]](diffhunk://#diff-f92e758934f17be597c0b9471e00bc520dd55b111d99d2435355ca3d37a71a11L485)
* Added a new method `isDefaultConfig` to compare browser configurations and reuse existing browser instances when possible.
* Enhanced the default launch configuration with additional options such as `args`, `blockAds`, and `extensions`.
* Improved the `launch` method to handle browser instance reuse and properly log the process. [[1]](diffhunk://#diff-f92e758934f17be597c0b9471e00bc520dd55b111d99d2435355ca3d37a71a11R405-R428) [[2]](diffhunk://#diff-f92e758934f17be597c0b9471e00bc520dd55b111d99d2435355ca3d37a71a11R522)
* Simplified session management by removing redundant shutdown calls in `startNewSession`.

### Updates to `SessionService`:

* Replaced the use of `Protocol.Network.CookieParam` with `CookieData` from `puppeteer-core` for better compatibility. [[1]](diffhunk://#diff-62d8f28189f9a0f71d0dd4abf85d264f8f22543ba9f009a763732c8de3905794L9-R9) [[2]](diffhunk://#diff-62d8f28189f9a0f71d0dd4abf85d264f8f22543ba9f009a763732c8de3905794L65-R65)
* Streamlined session configuration handling by directly assigning `sessionContext` and other parameters.

### Changes to `BrowserLauncherOptions`:

* Updated the `cookies` type in `sessionContext` to use `CookieData` from `puppeteer-core`.