### PR TITLE
fix: bug when dimensions are undefined

### DIFF
--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -165,7 +165,7 @@ export const handleGetSessionLiveDetails = async (
       status: server.sessionService.activeSession.status,
       userAgent: server.sessionService.activeSession.userAgent,
       browserVersion,
-      initialDimensions: server.sessionService.activeSession.dimensions,
+      initialDimensions: server.sessionService.activeSession.dimensions || { width: 1920, height: 1080 },
       pageCount: validPagesInfo.length,
     };
 


### PR DESCRIPTION
This pull request includes a small but important change to the `api/src/modules/sessions/sessions.controller.ts` file. The change ensures that the `initialDimensions` field has a default value if it is not already set.

* [`api/src/modules/sessions/sessions.controller.ts`](diffhunk://#diff-fc5a20a5ff673a4dbb6e9d7fdebe599ebf36602bca4ebe5b20cdaea8faf3399cL168-R168): Updated the `initialDimensions` field to default to `{ width: 1920, height: 1080 }` if no dimensions are provided.