### PR TITLE
fix: downgrade to puppeteer 23.6 for now

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -59,7 +59,7 @@ RUN cd api/extensions/recorder && npm prune --omit=dev && cd -
 FROM build AS patcher
 WORKDIR /app/api/patcher
 RUN npm i --include=dev
-RUN node ./scripts/patcher.js patch --packagePath /app/node_modules/puppeteer-core
+RUN node ./scripts/patcher.js patch --packagePath /app/api/node_modules/puppeteer-core
 
 FROM base AS production
 # Install dependencies

--- a/api/package.json
+++ b/api/package.json
@@ -47,7 +47,7 @@
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "proxy-chain": "^2.5.6",
-    "puppeteer-core": "^24.2.0",
+    "puppeteer-core": "23.6.0",
     "ts-node-dev": "^2.0.0",
     "turndown": "^7.2.0",
     "uuid": "^11.0.5",

--- a/api/patcher/scripts/patcher.js
+++ b/api/patcher/scripts/patcher.js
@@ -70,10 +70,9 @@ import { exec, fatalError, getPatchBaseCmd, getPatcherPackagePath, log, validPac
   }
   log(`Found package "${packageJson.name}", version ${packageJson.version}`);
 
-  //const patchFilePath = resolve(getPatcherPackagePath(), `./patches/${packageName}/${packageName === 'puppeteer-core' ? '23.6.x' : '1.47.x-lib'}.patch`)
   const patchFilePath = resolve(
     getPatcherPackagePath(),
-    `./patches/${packageName}/${packageName === "puppeteer-core" ? "22.13.x" : "1.47.x-lib"}.patch`,
+    `./patches/${packageName}/${packageName === "puppeteer-core" ? "23.6.x" : "1.47.x-lib"}.patch`,
   );
   // check patch status
   let patchStatus;

--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -3,6 +3,7 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { getErrors } from "../../utils/errors";
 import { CreateSessionRequest, SessionStreamRequest } from "./sessions.schema";
 import { env } from "../../env";
+import { Protocol } from "puppeteer-core";
 
 export const handleLaunchBrowserSession = async (
   server: FastifyInstance,
@@ -27,7 +28,10 @@ export const handleLaunchBrowserSession = async (
       sessionId,
       proxyUrl,
       userAgent,
-      sessionContext,
+      sessionContext: sessionContext as {
+        cookies?: Protocol.Network.Cookie[] | undefined;
+        localStorage?: Record<string, Record<string, any>> | undefined;
+      },
       extensions,
       logSinkUrl,
       timezone,

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -1,5 +1,5 @@
 import { FastifyBaseLogger } from "fastify";
-import { CookieData } from "puppeteer-core";
+import { Protocol } from "puppeteer-core";
 import { v4 as uuidv4 } from "uuid";
 import { env } from "../env";
 import { SessionDetails } from "../modules/sessions/sessions.schema";
@@ -70,7 +70,7 @@ export class SessionService {
     proxyUrl?: string;
     userAgent?: string;
     sessionContext?: {
-      cookies?: CookieData[];
+      cookies?: Protocol.Network.Cookie[];
       localStorage?: Record<string, Record<string, any>>;
     };
     isSelenium?: boolean;

--- a/api/src/types/browser.ts
+++ b/api/src/types/browser.ts
@@ -1,12 +1,11 @@
-import { CookieData } from "puppeteer-core";
 import { BrowserEventType } from "./enums";
-
+import { Protocol } from "puppeteer-core";
 export interface BrowserLauncherOptions {
   options: BrowserServerOptions;
   req?: Request;
   stealth?: boolean;
   sessionContext?: {
-    cookies?: CookieData[];
+    cookies?: Protocol.Network.Cookie[];
     localStorage?: Record<string, Record<string, any>>;
   };
   userAgent?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
         "proxy-chain": "^2.5.6",
-        "puppeteer-core": "^24.2.0",
+        "puppeteer-core": "23.6.0",
         "ts-node-dev": "^2.0.0",
         "turndown": "^7.2.0",
         "uuid": "^11.0.5",
@@ -66,6 +66,69 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.7.3",
         "vite": "^6.1.0"
+      }
+    },
+    "api/node_modules/@puppeteer/browsers": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.0.tgz",
+      "integrity": "sha512-x8J1csfIygOwf6D6qUAZ0ASk3z63zPb7wkNeHRerCMh82qWKUrOgkuP005AJC8lDL6/evtXETGEJVcwykKT4/g==",
+      "dependencies": {
+        "debug": "^4.3.6",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.4.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "api/node_modules/chromium-bidi": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.8.0.tgz",
+      "integrity": "sha512-uJydbGdTw0DEUjhoogGveneJVWX/9YuqkWePzMmkBYwtdAqo5d3J/ovNKFr+/2hWXYmYCr6it8mSSTIj6SS6Ug==",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "api/node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "api/node_modules/devtools-protocol": {
+      "version": "0.0.1354347",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1354347.tgz",
+      "integrity": "sha512-BlmkSqV0V84E2WnEnoPnwyix57rQxAM5SKJjf4TbYOCGLAWtz8CDH8RIaGOjPgPCXo2Mce3kxSY497OySidY3Q=="
+    },
+    "api/node_modules/puppeteer-core": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.6.0.tgz",
+      "integrity": "sha512-se1bhgUpR9C529SgHGr/eyT92mYyQPAhA2S9pGtGrVG2xob9qE6Pbp7TlqiSPlnnY1lINqhn6/67EwkdzOmKqQ==",
+      "dependencies": {
+        "@puppeteer/browsers": "2.4.0",
+        "chromium-bidi": "0.8.0",
+        "debug": "^4.3.7",
+        "devtools-protocol": "0.0.1354347",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -5095,7 +5158,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5319,7 +5381,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7574,7 +7635,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10661,8 +10721,7 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
@@ -11083,7 +11142,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
       "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-      "dev": true,
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -11149,6 +11207,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",


### PR DESCRIPTION
This pull request includes several changes to the `api` package, primarily focusing on downgrading the `puppeteer-core` version and updating the usage of `CookieData` to `Protocol.Network.Cookie`. The most important changes are summarized below:

### Version Downgrade:

* [`api/package.json`](diffhunk://#diff-d0ab9c1cc78fba971b5270314ad877706d340d099b42f46a406fc5de6a32fdf0L50-R50): Downgraded `puppeteer-core` from version `24.2.0` to `23.6.0`.

### Code Updates for Compatibility:

* [`api/patcher/scripts/patcher.js`](diffhunk://#diff-0528fe9db37e9d10f356bf3a407f455744b880d3a64ff08ac82fca1a3b7691eaL73-R75): Updated the patch file path to use `23.6.x` for `puppeteer-core` instead of `22.13.x`.
* [`api/src/modules/sessions/sessions.controller.ts`](diffhunk://#diff-fc5a20a5ff673a4dbb6e9d7fdebe599ebf36602bca4ebe5b20cdaea8faf3399cR6): Imported `Protocol` from `puppeteer-core` and updated `sessionContext` to use `Protocol.Network.Cookie[]`. [[1]](diffhunk://#diff-fc5a20a5ff673a4dbb6e9d7fdebe599ebf36602bca4ebe5b20cdaea8faf3399cR6) [[2]](diffhunk://#diff-fc5a20a5ff673a4dbb6e9d7fdebe599ebf36602bca4ebe5b20cdaea8faf3399cL30-R34)
* [`api/src/services/session.service.ts`](diffhunk://#diff-62d8f28189f9a0f71d0dd4abf85d264f8f22543ba9f009a763732c8de3905794L2-R2): Replaced `CookieData` with `Protocol.Network.Cookie[]` in `sessionContext`. [[1]](diffhunk://#diff-62d8f28189f9a0f71d0dd4abf85d264f8f22543ba9f009a763732c8de3905794L2-R2) [[2]](diffhunk://#diff-62d8f28189f9a0f71d0dd4abf85d264f8f22543ba9f009a763732c8de3905794L73-R73)
* [`api/src/types/browser.ts`](diffhunk://#diff-04dd05b60b88bb4031ea8990a887bde5b74b6e5da772a50e6ba07e6fa057f044L1-R8): Updated `sessionContext` to use `Protocol.Network.Cookie[]` instead of `CookieData`.