### PR TITLE
Use correct URLs for session

### DIFF
--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -84,10 +84,10 @@ export const handleGetSessionDetails = async (
       eventCount: 0,
       timeout: 0,
       creditsUsed: 0,
-      websocketUrl: `ws://${env.DOMAIN ?? env.HOST}/`,
-      debugUrl: `http://${env.DOMAIN ?? env.HOST}:${env.PORT}/v1/devtools/inspector.html`,
+      websocketUrl: `ws://${env.DOMAIN ?? env.HOST}:${env.PORT}/`,
+      debugUrl: `http://${env.DOMAIN ?? env.HOST}:${env.PORT}/v1/sessions/debug`,
       debuggerUrl: `http://${env.DOMAIN ?? env.HOST}:${env.PORT}/v1/devtools/inspector.html`,
-      sessionViewerUrl: `http://${env.DOMAIN ?? env.HOST}`,
+      sessionViewerUrl: `http://${env.DOMAIN ?? env.HOST}:${env.PORT}`,
       userAgent: "",
       isSelenium: false,
       proxy: "",
@@ -108,7 +108,7 @@ export const handleGetSessionStream = async (
 ) => {
   const { showControls, theme, interactive } = request.query;
   return reply.view("live-session-streamer.ejs", {
-    wsUrl: `ws://${env.DOMAIN ?? `${env.HOST}:${env.PORT}`}/v1/sessions/cast`,
+    wsUrl: `ws://${env.DOMAIN ?? env.HOST}:${env.PORT}/v1/sessions/cast`,
     showControls,
     theme,
     interactive,

--- a/api/src/plugins/schemas.ts
+++ b/api/src/plugins/schemas.ts
@@ -36,7 +36,7 @@ const schemaPlugin: FastifyPluginAsync = async (fastify) => {
       },
       servers: [
         {
-          url: `http://${env.DOMAIN ?? `${env.HOST}:${env.PORT}`}`,
+          url: `http://${env.DOMAIN ?? env.HOST}:${env.PORT}`,
           description: "Local server",
         },
       ],


### PR DESCRIPTION
The service is configuring URLs with a port included in the domain: https://github.com/steel-dev/steel-browser/blob/c5ea013e03733b3c283fd9aa7941a258d55a9427/api/src/services/session.service.ts#L32...L35.  

However, this isn't consistent across other parts of the code, so I'm raising a fix for it.