### PR TITLE
fix: allow overriding default tz

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -36,6 +36,7 @@ const envSchema = z.object({
     .optional()
     .transform((val) => val !== "false")
     .default("false"),
+  DEFAULT_TIMEZONE: z.string().optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/api/src/services/cdp.service.ts
+++ b/api/src/services/cdp.service.ts
@@ -40,7 +40,7 @@ export class CDPService extends EventEmitter {
     this.wsEndpoint = null;
     this.fingerprintData = null;
     this.chromeExecPath = getChromeExecutablePath();
-    this.defaultTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    this.defaultTimezone = env.DEFAULT_TIMEZONE || Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     // Clean up any existing proxy server
     if (this.wsProxyServer) {


### PR DESCRIPTION
This pull request includes changes to support configurable time zones in the `api` module. The most important changes include adding a new environment variable for the default time zone and updating the `CDPService` class to use this new variable.

Improvements to time zone configuration:

* [`api/src/env.ts`](diffhunk://#diff-08db4c2c874e5cb71cb4b6caf511f45f26a590a4592fd6d2ebb2a1f0d580a5f3R39): Added `DEFAULT_TIMEZONE` as an optional string in the environment schema.
* [`api/src/services/cdp.service.ts`](diffhunk://#diff-f92e758934f17be597c0b9471e00bc520dd55b111d99d2435355ca3d37a71a11L43-R43): Modified the `CDPService` class to use the `DEFAULT_TIMEZONE` environment variable, falling back to the system's time zone if not set.