### PR TITLE
fix: error with session details

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -4,6 +4,7 @@ import { config } from "dotenv";
 config();
 
 const envSchema = z.object({
+  NODE_ENV: z.enum(["development", "production"]).default("development"),
   HOST: z.string().optional().default("0.0.0.0"),
   DOMAIN: z.string().optional(),
   PORT: z.string().optional().default("3000"),

--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -1,7 +1,7 @@
 import { CDPService } from "../../services/cdp.service";
 import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { getErrors } from "../../utils/errors";
-import { CreateSessionRequest, SessionStreamRequest } from "./sessions.schema";
+import { CreateSessionRequest, SessionDetails, SessionStreamRequest } from "./sessions.schema";
 import { env } from "../../env";
 import { Protocol } from "puppeteer-core";
 
@@ -91,8 +91,10 @@ export const handleGetSessionDetails = async (
       userAgent: "",
       isSelenium: false,
       proxy: "",
+      proxyTxBytes: 0,
+      proxyRxBytes: 0,
       solveCaptcha: false,
-    });
+    } as SessionDetails);
   }
   return reply.send(server.sessionService.activeSession);
 };

--- a/api/src/services/file.service.ts
+++ b/api/src/services/file.service.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { Readable, Transform } from "stream";
 import { pipeline } from "stream/promises";
 import { v4 as uuidv4 } from "uuid";
+import { env } from "../env";
 
 interface File {
   name: string;
@@ -25,7 +26,7 @@ export class FileService {
 
   constructor(_config: {}, logger: FastifyBaseLogger) {
     this.logger = logger;
-    this.baseDownloadPath = process.env.NODE_ENV === "development" ? path.join(process.cwd(), "/files") : "/files";
+    this.baseDownloadPath = env.NODE_ENV === "development" ? path.join(process.cwd(), "/files") : "/files";
     fs.mkdirSync(this.baseDownloadPath, { recursive: true });
     this.fileMap = new Map();
   }


### PR DESCRIPTION
### Environment Variable Handling:

* [`api/src/env.ts`](diffhunk://#diff-08db4c2c874e5cb71cb4b6caf511f45f26a590a4592fd6d2ebb2a1f0d580a5f3R7): Added default value for `NODE_ENV` to ensure it defaults to "development" if not specified.

### Session Details Enhancement:

* [`api/src/modules/sessions/sessions.controller.ts`](diffhunk://#diff-fc5a20a5ff673a4dbb6e9d7fdebe599ebf36602bca4ebe5b20cdaea8faf3399cL4-R4): Added `SessionDetails` import and updated session details to include `proxyTxBytes` and `proxyRxBytes` fields. [[1]](diffhunk://#diff-fc5a20a5ff673a4dbb6e9d7fdebe599ebf36602bca4ebe5b20cdaea8faf3399cL4-R4) [[2]](diffhunk://#diff-fc5a20a5ff673a4dbb6e9d7fdebe599ebf36602bca4ebe5b20cdaea8faf3399cR94-R97)

### Code Refactoring:

* [`api/src/services/file.service.ts`](diffhunk://#diff-46509af95f64e20d45abb962580f0978ab6000a9fea6881deb13ea362ae402aeR9): Refactored to use the `env` object for `NODE_ENV` instead of directly accessing `process.env`. [[1]](diffhunk://#diff-46509af95f64e20d45abb962580f0978ab6000a9fea6881deb13ea362ae402aeR9) [[2]](diffhunk://#diff-46509af95f64e20d45abb962580f0978ab6000a9fea6881deb13ea362ae402aeL28-R29)