### PR TITLE
fix: dont calculate proxy usage on internal calls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,9 @@ services:
   ui:
     image: ghcr.io/steel-dev/steel-browser-ui:latest
     ports:
-      - "5173:5173"
+      - "5173:80"
+    environment:
+      - API_URL=${API_URL:-http://api:3000}
     depends_on:
       - api
     networks:


### PR DESCRIPTION
This pull request includes changes to the `ProxyServer` class in `api/src/utils/proxy.ts` and updates to the `docker-compose.yml` file. The most important changes focus on managing host connections and updating the Docker configuration.

Enhancements to `ProxyServer`:

* Introduced a `hostConnections` set to track connection IDs in the `ProxyServer` class.
* Updated the `prepareRequestFunction` to add `connectionId` to the `hostConnections` set when the hostname matches the environment host.
* Modified the `connectionClosed` event handler to check if the `connectionId` is in the `hostConnections` set before updating byte statistics and to remove the `connectionId` from the set.

Docker configuration updates:

* Changed the port mapping for the `ui` service in `docker-compose.yml` from `5173:5173` to `5173:80`.
* Added an `environment` variable `API_URL` for the `ui` service in `docker-compose.yml`.