### PR TITLE
fix: add @rrweb/packer support and event unpacking logic

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -38,6 +38,9 @@ RUN npm ci --include=dev --workspace=api --ignore-scripts
 # Install dependencies for recorder extension separately
 RUN cd api/extensions/recorder && npm ci --include=dev && cd -
 
+# Install @rrweb/packer explicitly
+RUN cd api && npm install @rrweb/packer && cd -
+
 # Build the api package
 RUN npm run build -w api
 
@@ -45,8 +48,9 @@ RUN cd api/extensions/recorder && \
     npm run build && \
     cd -
 
-# Prune dev dependencies
+# Prune dev dependencies but keep @rrweb/packer
 RUN npm prune --omit=dev -w api
+RUN cd api && npm install @rrweb/packer --save-prod && cd -
 RUN cd api/extensions/recorder && npm prune --omit=dev && cd -
 
 FROM base AS production

--- a/api/package.json
+++ b/api/package.json
@@ -33,6 +33,7 @@
     "@fastify/view": "10.0.2",
     "@fastify/vite": "^7.0.1",
     "@mozilla/readability": "^0.5.0",
+    "@rrweb/packer": "^2.0.0-alpha.18",
     "@scalar/fastify-api-reference": "^1.25.116",
     "@types/mime-types": "^2.1.4",
     "axios": "^1.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@fastify/view": "10.0.2",
         "@fastify/vite": "^7.0.1",
         "@mozilla/readability": "^0.5.0",
+        "@rrweb/packer": "^2.0.0-alpha.18",
         "@scalar/fastify-api-reference": "^1.25.116",
         "@types/mime-types": "^2.1.4",
         "axios": "^1.8.4",
@@ -66,7 +67,6 @@
         "zod-to-json-schema": "^3.24.1"
       },
       "devDependencies": {
-        "@types/dotenv": "^8.2.3",
         "@types/json-stringify-safe": "^5.0.3",
         "@types/node": "^22.13.1",
         "@types/ws": "^8.5.14",
@@ -4204,6 +4204,15 @@
         "darwin"
       ]
     },
+    "node_modules/@rrweb/packer": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/@rrweb/packer/-/packer-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-rEXltE/gnflEv/NatVNPIp4/6EtVlPLSwzIbd4WPSMtQGvwZe5OfAAk/Y88HkbAwb1nHfdA3PtFGn2Epik4inQ==",
+      "dependencies": {
+        "@rrweb/types": "^2.0.0-alpha.18",
+        "fflate": "^0.4.4"
+      }
+    },
     "node_modules/@rrweb/types": {
       "version": "2.0.0-alpha.18",
       "license": "MIT"
@@ -4676,15 +4685,6 @@
     "node_modules/@types/css-font-loading-module": {
       "version": "0.0.7",
       "license": "MIT"
-    },
-    "node_modules/@types/dotenv": {
-      "version": "8.2.3",
-      "deprecated": "This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dotenv": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",


### PR DESCRIPTION
**Problem: Improper Handling of Compressed Data**

rrweb utilizes `@rrweb/packer` to compress event data.  The server-side implementation was incorrectly treating and storing the compressed binary data as a regular string. This resulted in the UI being unable to properly render the browser's screen recording.

- Add event unpacking logic in sessions.routes.ts
- Improve error handling for compressed events
- Add @rrweb/packer dependency to package.json
- Update Dockerfile to handle new dependency