### PR TITLE
feat: added ability to pass chrome args to new sessions via .env or docker-compose

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -43,6 +43,7 @@ const envSchema = z.object({
     .optional()
     .transform((val) => val !== "false" && val !== "")
     .default("false"),
+  CHROME_ARGS: z.string().optional().default(""),
 });
 
 export const env = envSchema.parse(process.env);

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -91,15 +91,15 @@ export class SessionService {
     dimensions?: { width: number; height: number };
     extra?: Record<string, Record<string, string>>;
   }): Promise<SessionDetails> {
-    const { 
-      sessionId, 
-      proxyUrl, 
-      userAgent, 
-      sessionContext, 
-      extensions, 
-      logSinkUrl, 
-      dimensions, 
-      isSelenium, 
+    const {
+      sessionId,
+      proxyUrl,
+      userAgent,
+      sessionContext,
+      extensions,
+      logSinkUrl,
+      dimensions,
+      isSelenium,
       blockAds,
       extra,
     } = options;
@@ -157,14 +157,15 @@ export class SessionService {
       }
     }
 
-    
     const userDataDir = path.join(os.tmpdir(), sessionInfo.id);
     await mkdir(userDataDir, { recursive: true });
 
     const browserLauncherOptions: BrowserLauncherOptions = {
       options: {
         headless: env.CHROME_HEADLESS,
-        args: [userAgent ? `--user-agent=${userAgent}` : undefined].filter(Boolean) as string[],
+        args: [...env.CHROME_ARGS.split(" "), userAgent ? `--user-agent=${userAgent}` : undefined].filter(
+          Boolean,
+        ) as string[],
         proxyUrl: this.activeSession.proxyServer?.url,
       },
       sessionContext,


### PR DESCRIPTION
Updated env.ts to show CHROME_ARGS env variable and spreads CHROME_ARGS into browser launch args