### PR TITLE
fix: remove graceful shutdown

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -52,7 +52,6 @@
     "chokidar": "^4.0.3",
     "dotenv": "^16.4.7",
     "ejs": "^3.1.10",
-    "fastify-graceful-shutdown": "^4.0.1",
     "fastify-plugin": "^5.0.1",
     "file-type": "^20.4.1",
     "fingerprint-generator": "^2.1.62",

--- a/api/src/plugins/browser-session.ts
+++ b/api/src/plugins/browser-session.ts
@@ -1,8 +1,6 @@
-import fastifyGracefulShutdown from "fastify-graceful-shutdown";
 import { FastifyPluginAsync } from "fastify";
 import fp from "fastify-plugin";
 import { SessionService } from "../services/session.service.js";
-import { env } from "../env.js";
 
 const browserSessionPlugin: FastifyPluginAsync = async (fastify, _options) => {
   const sessionService = new SessionService({
@@ -12,29 +10,6 @@ const browserSessionPlugin: FastifyPluginAsync = async (fastify, _options) => {
     logger: fastify.log,
   });
   fastify.decorate("sessionService", sessionService);
-
-  process.removeAllListeners("SIGINT");
-  process.removeAllListeners("SIGTERM");
-
-  const gracefulOptions = {
-    timeout: parseInt(env.KILL_TIMEOUT) * 1000,
-  };
-  fastify.register(fastifyGracefulShutdown, gracefulOptions).after((err) => {
-    if (err) {
-      fastify.log.error(err);
-    }
-
-    fastify.gracefulShutdown(async (_signal) => {
-      if (sessionService.activeSession.status === "live") {
-        fastify.log.info("Waiting for active session to be released...");
-        await sessionService.activeSession.completion;
-        fastify.log.info("Active session has been released...");
-      }
-
-      await fastify.cdpService.shutdown();
-      await fastify.seleniumService.close();
-    });
-  });
 };
 
 export default fp(browserSessionPlugin, "5.x");


### PR DESCRIPTION
This pull request removes the `fastify-graceful-shutdown` dependency and replaces its functionality with a custom implementation in the `CDPService` class. Additionally, it introduces a timeout mechanism for browser launches and includes minor formatting updates.

### Removal of `fastify-graceful-shutdown`:

* Removed the `fastify-graceful-shutdown` package from `api/package.json` and its import from `api/src/plugins/browser-session.ts`. [[1]](diffhunk://#diff-d0ab9c1cc78fba971b5270314ad877706d340d099b42f46a406fc5de6a32fdf0L55) [[2]](diffhunk://#diff-b4dbad64e9719420374f56d879f450d59e06b4f1178e9c4349f7a70fcc7685b5L1-L5)
* Deleted the graceful shutdown logic from `browserSessionPlugin`, including signal listeners and session cleanup logic.

### Enhancements to `CDPService`:

* Introduced a timeout mechanism for browser launches to ensure the process fails gracefully if it exceeds 30 seconds. [[1]](diffhunk://#diff-a9d2d6cd79aa58bc3278337df6c472501ccf6450a80b75441ae1600921a03f9dR479-R484) [[2]](diffhunk://#diff-a9d2d6cd79aa58bc3278337df6c472501ccf6450a80b75441ae1600921a03f9dR610-R616)
* Enabled Chrome process stdout and stderr logging by setting `dumpio: true` in the browser launch options.

### Code formatting:

* Adjusted the formatting of the `--window-size` argument for better readability.