### PR TITLE
Hotfix: scalar fastify plugin still uses v4

### DIFF
--- a/api/src/plugins/schemas.ts
+++ b/api/src/plugins/schemas.ts
@@ -52,7 +52,7 @@ const schemaPlugin: FastifyPluginAsync = async (fastify) => {
     },
   });
 
-  await fastify.register(fastifyScalar, {
+  await fastify.register(fastifyScalar as any, { // scalar still uses fastify v4
     routePrefix: "/documentation",
     configuration: {
       customCss: scalarTheme,


### PR DESCRIPTION
Resolves a build issue for type mismatch