### PR TITLE
Add credentials option to create session

### DIFF
--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -23,6 +23,7 @@ export const handleLaunchBrowserSession = async (
       isSelenium,
       blockAds,
       extra,
+      credentials,
     } = request.body;
 
     return await server.sessionService.startSession({
@@ -40,6 +41,7 @@ export const handleLaunchBrowserSession = async (
       isSelenium,
       blockAds,
       extra,
+      credentials,
     });
   } catch (e: unknown) {
     server.log.error("Failed lauching browser session", e);

--- a/api/src/modules/sessions/sessions.schema.ts
+++ b/api/src/modules/sessions/sessions.schema.ts
@@ -25,6 +25,10 @@ const CreateSession = z.object({
     .record(z.string(), z.record(z.string(), z.string()))
     .optional()
     .describe("Extra metadata to help initialize the session"),
+  credentials: z
+    .union([z.boolean(), z.literal("auto")])
+    .default(false)
+    .describe("Enables credential injection for secure auth"),
 });
 
 const SessionDetails = z.object({

--- a/api/src/services/cdp-lifecycle.service.ts
+++ b/api/src/services/cdp-lifecycle.service.ts
@@ -1,8 +1,0 @@
-import { BrowserLauncherOptions } from "../types/index.js";
-
-export namespace CDPLifecycle {
-  export async function launch(_config?: BrowserLauncherOptions | null) {
-  }
-  export async function shutdown(_config?: BrowserLauncherOptions | null) {
-  }
-}

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -25,7 +25,6 @@ import { getExtensionPaths } from "../../utils/extensions.js";
 import { ChromeContextService } from "../context/chrome-context.service.js";
 import { SessionData } from "../context/types.js";
 import { PluginManager } from "./plugins/core/plugin-manager.js";
-import { CDPLifecycle } from "../cdp-lifecycle.service.js";
 
 export class CDPService extends EventEmitter {
   private logger: FastifyBaseLogger;
@@ -417,7 +416,6 @@ export class CDPService extends EventEmitter {
   }
 
   private async shutdownHook() {
-    await CDPLifecycle.shutdown(this.currentSessionConfig); // backwards compat
     for (const mutator of this.shutdownMutators) {
       await mutator(this.currentSessionConfig);
     }
@@ -517,7 +515,6 @@ export class CDPService extends EventEmitter {
 
         const timezone = config?.timezone || this.defaultTimezone;
 
-        await CDPLifecycle.launch(this.launchConfig); // backwards compat
         for (const mutator of this.launchMutators) {
           await mutator(this.launchConfig);
         }

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -90,6 +90,7 @@ export class SessionService {
     timezone?: string;
     dimensions?: { width: number; height: number };
     extra?: Record<string, Record<string, string>>;
+    credentials: boolean | "auto";
   }): Promise<SessionDetails> {
     const {
       sessionId,
@@ -102,6 +103,7 @@ export class SessionService {
       isSelenium,
       blockAds,
       extra,
+      credentials,
     } = options;
 
     let timezone = options.timezone;
@@ -177,6 +179,7 @@ export class SessionService {
       dimensions,
       userDataDir,
       extra,
+      credentials,
     };
 
     if (isSelenium) {

--- a/api/src/types/browser.ts
+++ b/api/src/types/browser.ts
@@ -23,6 +23,7 @@ export interface BrowserLauncherOptions {
   } | null;
   userDataDir?: string;
   extra?: Record<string, Record<string, string>>;
+  credentials?: boolean | "auto";
 }
 
 export interface BrowserServerOptions {


### PR DESCRIPTION
Removes the legacy life cycle hooks and adds a new `credentials` option to the sessions API.