### PR TITLE
fix: make chrome debugging optional with env var

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -49,6 +49,11 @@ const envSchema = z.object({
     .transform((val) => val === "true" || val === "1")
     .default("false"),
   CHROME_ARGS: z.string().optional().default(""),
+  DEBUG_CHROME_PROCESS: z
+    .string()
+    .optional()
+    .transform((val) => val === "true" || val === "1")
+    .default("false"),
 });
 
 export const env = envSchema.parse(process.env);

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -568,7 +568,7 @@ export class CDPService extends EventEmitter {
             TZ: timezone,
           },
           userDataDir,
-          dumpio: true, // Enable Chrome process stdout and stderr
+          dumpio: env.DEBUG_CHROME_PROCESS, // Enable Chrome process stdout and stderr
         };
 
         this.logger.info(`[CDPService] Launch Options:`);


### PR DESCRIPTION
`DEBUG_CHROME_PROCESS` introduced to control whether Chrome process stdout and stderr are enabled.

### Environment configuration updates:
* Added a new optional environment variable, `DEBUG_CHROME_PROCESS`, to the `envSchema` in `api/src/env.ts`. This variable is transformed to a boolean and defaults to `"false"`.

### Chrome DevTools Protocol (CDP) service updates:
* Updated the `dumpio` property in the Chrome launch options to use the new `DEBUG_CHROME_PROCESS` environment variable, allowing dynamic control of Chrome process logging.