### PR TITLE
Add OpenTelemetry API to CDP Services

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -26,6 +26,7 @@
   },
   "author": "Nasr Mohamed",
   "devDependencies": {
+    "@opentelemetry/api": "1.9.0",
     "@types/archiver": "^6.0.3",
     "@types/iconv-lite": "^0.0.1",
     "@types/json-stringify-safe": "^5.0.3",
@@ -81,6 +82,15 @@
     "cross-spawn": "^7.0.6"
   },
   "peerDependencies": {
-    "fastify": "^5.0.0"
-  }
+    "fastify": "^5.0.0",
+    "@opentelemetry/api": "1.9.0"
+  },
+  "peerDependenciesMeta": {
+		"fastify": {
+			"optional": false
+		},
+		"@opentelemetry/api": {
+			"optional": true
+		}
+	}
 }

--- a/api/src/telemetry/noop.ts
+++ b/api/src/telemetry/noop.ts
@@ -1,0 +1,38 @@
+import type { Span } from "@opentelemetry/api";
+
+export const noopSpan: Span = {
+  spanContext() {
+    return {
+      traceId: '',
+      spanId: '',
+      traceFlags: 0,
+      isRemote: false,
+    };
+  },
+  setAttribute() {
+    return this;
+  },
+  setAttributes() {
+    return this;
+  },
+  addEvent() {
+    return this;
+  },
+  addLink() {
+    return this;
+  },
+  addLinks() {
+    return this;
+  },
+  setStatus() {
+    return this;
+  },
+  updateName() {
+    return this;
+  },
+  end() {},
+  isRecording() {
+    return false;
+  },
+  recordException() {},
+};

--- a/api/src/telemetry/tracer.ts
+++ b/api/src/telemetry/tracer.ts
@@ -1,0 +1,122 @@
+import type { Span, SpanOptions } from "@opentelemetry/api";
+import { noopSpan } from "./noop";
+
+let otel: typeof import('@opentelemetry/api') | undefined;
+
+interface TracerOptions extends SpanOptions {
+  spanName?: string;
+  tracerName?: string;
+}
+
+export const tracer = {
+  startActiveSpan<F extends (span: Span) => unknown>(
+    name: string,
+    fn: F,
+    opts?: Omit<TracerOptions, 'spanName'>
+  ): ReturnType<F> {
+    if (!otel) {
+			return fn(noopSpan) as ReturnType<F>;
+		}
+
+    const { tracerName, ...options } = opts ?? {};
+    const rawTracer = otel.trace.getTracer(tracerName ?? "steel");
+
+    return rawTracer.startActiveSpan(name, options ?? {}, (span: Span) => {
+      try {
+        const result = fn(span);
+
+        if (result instanceof Promise) {
+          return result
+            .catch((error: Error) => {
+              span.recordException(error);
+              span.setStatus({
+                code: otel.SpanStatusCode.ERROR,
+                message: error.message,
+              });
+              throw error;
+            })
+            .finally(() => {
+              span.end();
+            }) as ReturnType<F>;
+        }
+
+        span.setStatus({ code: otel.SpanStatusCode.OK });
+        span.end();
+        return result as ReturnType<F>;
+      } catch (error: any) {
+        span.recordException(error);
+        span.setStatus({
+          code: otel.SpanStatusCode.ERROR,
+          message: error.message,
+        });
+        span.end();
+        throw error;
+      }
+    });
+  },
+  factory(tracerName: string) {
+    return {
+      startActiveSpan<F extends (span: Span) => unknown>(
+        name: string,
+        fn: F,
+        opts?: Omit<TracerOptions, 'spanName' | 'tracerName'>
+      ): ReturnType<F> {
+        return tracer.startActiveSpan(name, fn, { ...opts, tracerName });
+      },
+    };
+  },
+};
+
+export function traceable(target: Object, propertyKey: string, descriptor: PropertyDescriptor): void;
+export function traceable(opts?: TracerOptions): MethodDecorator;
+export function traceable(
+  targetOrOpts?: any,
+  propertyKey?: string,
+  descriptor?: PropertyDescriptor
+): any {
+  // Used as @traceable
+  if (typeof targetOrOpts === 'object' && propertyKey !== undefined && descriptor !== undefined) {
+    return createDecorator()(targetOrOpts, propertyKey, descriptor);
+  }
+
+  // Used as @traceable({...})
+  return createDecorator(targetOrOpts as TracerOptions | undefined);
+}
+
+function createDecorator(opts?: TracerOptions) {
+  const { spanName, tracerName, ...options } = opts ?? {};
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    if (!otel) {
+			return descriptor;
+		}
+
+    const originalMethod = descriptor.value;
+
+    descriptor.value = function (...args: any[]) {
+      const tracername = tracerName ?? toKebabCase(target.constructor.name);
+      const name = spanName ?? `${target.constructor.name}.${propertyKey}`;
+
+      return tracer.startActiveSpan(
+        name,
+        () => {
+          return originalMethod.apply(this, args);
+        },
+        {
+          ...options,
+          tracerName: tracername,
+        },
+      );
+    };
+  };
+}
+
+function toKebabCase(str: string) {
+  return str
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+}

--- a/api/src/telemetry/tracer.ts
+++ b/api/src/telemetry/tracer.ts
@@ -2,6 +2,14 @@ import type { Span, SpanOptions } from "@opentelemetry/api";
 import { noopSpan } from "./noop";
 
 let otel: typeof import('@opentelemetry/api') | undefined;
+try {
+	otel = await import('@opentelemetry/api');
+} catch (err: any) {
+	if (err?.code !== 'MODULE_NOT_FOUND' && err?.code !== 'ERR_MODULE_NOT_FOUND') {
+		throw err;
+	}
+}
+
 
 interface TracerOptions extends SpanOptions {
   spanName?: string;

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -12,7 +12,9 @@
     "noImplicitAny": false,
     "strict": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
   },
   "include": ["src"],
   "files": ["./src/types/fastify.d.ts", "src/services/cdp/plugins/pptr-extensions.d.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "zod-to-json-schema": "^3.24.1"
       },
       "devDependencies": {
+        "@opentelemetry/api": "1.9.0",
         "@types/archiver": "^6.0.3",
         "@types/iconv-lite": "^0.0.1",
         "@types/json-stringify-safe": "^5.0.3",
@@ -87,7 +88,16 @@
         "vite": "^6.3.5"
       },
       "peerDependencies": {
+        "@opentelemetry/api": "1.9.0",
         "fastify": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "fastify": {
+          "optional": false
+        }
       }
     },
     "api/node_modules/@puppeteer/browsers": {
@@ -2902,6 +2912,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {


### PR DESCRIPTION
This adds the OpenTelemetry's API as an optional dependency, if enabled and your server has the appropriate instrumentation you can collect the additional spans associated with the CDP service. Includes necessary helpers for creating new spans.