### PR TITLE
Add environment variable to bypass internal hosts in proxy

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -64,6 +64,7 @@ const envSchema = z.object({
     .optional()
     .transform((val) => val === "true" || val === "1")
     .default("false"),
+  PROXY_INTERNAL_BYPASS: z.string().optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/api/src/utils/proxy.ts
+++ b/api/src/utils/proxy.ts
@@ -1,3 +1,4 @@
+import { env } from "../env.js";
 import { SessionService } from "../services/session.service.js";
 import { Server } from "proxy-chain";
 
@@ -13,7 +14,13 @@ export class ProxyServer extends Server {
       port: 0,
 
       prepareRequestFunction: ({ connectionId, hostname }) => {
-        if (hostname === process.env.HOST) {
+        const internalBypassTests = ["0.0.0.0", process.env.HOST];
+        if (env.PROXY_INTERNAL_BYPASS) {
+          internalBypassTests.push(...env.PROXY_INTERNAL_BYPASS.split(","));
+        }
+        const isInternalBypass = internalBypassTests.includes(hostname);
+
+        if (isInternalBypass) {
           this.hostConnections.add(connectionId);
           return {
             requestAuthentication: false,


### PR DESCRIPTION
This introduces a `PROXY_INTERNAL_BYPASS` environment variable which you can pass a comma-delimited list of hosts to which will then be skipped in the proxy layer from steel-browser.