### PR TITLE
fix: esm import error causing build issue

### DIFF
--- a/api/src/services/cdp/utils/validation.ts
+++ b/api/src/services/cdp/utils/validation.ts
@@ -1,5 +1,5 @@
 import { BrowserLauncherOptions } from "../../../types";
-import { ConfigurationError, ResourceError, ConfigurationField } from "../errors/launch-errors";
+import { ConfigurationError, ConfigurationField } from "../errors/launch-errors.js";
 
 /**
  * Validates a givenlaunch configuration (not conclusive)


### PR DESCRIPTION
This pull request includes a minor update to the `validation.ts` file. It removes the unused `ResourceError` import and updates the import path for `launch-errors` to include the `.js` file extension.