### PR TITLE
feat: better ws handling logic + registry & options for adding custom handlers

### DIFF
--- a/api/src/plugins/browser-socket/browser-socket.ts
+++ b/api/src/plugins/browser-socket/browser-socket.ts
@@ -1,113 +1,71 @@
 import { type FastifyInstance, type FastifyPluginAsync } from "fastify";
 import fp from "fastify-plugin";
-import { WebSocketServer, WebSocket } from 'ws';
-import { EmitEvent } from "../../types/enums.js";
-import { handleCastSession } from "./casting.handler.js";
+import { WebSocketServer } from "ws";
+import { WebSocketRegistryService } from "../../services/websocket-registry.service.js";
+import { WebSocketHandler, WebSocketHandlerContext } from "../../types/websocket.js";
+import { defaultHandlers } from "./handlers/index.js";
+
+export interface BrowserSocketOptions {
+  customHandlers?: WebSocketHandler[];
+}
 
 // WebSocket server instance
 const wss = new WebSocketServer({ noServer: true });
 
-// WebSocket handlers
-function handleLogsWebSocket(fastify: FastifyInstance, ws: WebSocket) {
-  const messageHandler = (payload: { pageId: string }) => {
-    if (ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify([payload]));
-    }
-  };
-
-  fastify.cdpService.on(EmitEvent.Log, messageHandler);
-
-  ws.on("error", (err) => {
-    fastify.log.error("PageId WebSocket error:", err);
-  });
-
-  ws.on("close", () => {
-    fastify.log.info("PageId WebSocket connection closed");
-    fastify.cdpService.removeListener(`log`, messageHandler);
-  });
-}
-
-const browserWebSocket: FastifyPluginAsync = async (fastify: FastifyInstance, options: any) => {
+const browserWebSocket: FastifyPluginAsync<BrowserSocketOptions> = async (
+  fastify: FastifyInstance,
+  options: BrowserSocketOptions,
+) => {
   if (!fastify.cdpService.isRunning()) {
     fastify.log.info("Launching browser...");
     await fastify.cdpService.launch();
     fastify.log.info("Browser launched successfully");
   }
 
+  const registry = new WebSocketRegistryService();
+
+  defaultHandlers.forEach((handler) => {
+    registry.registerHandler(handler);
+  });
+
+  if (options.customHandlers) {
+    options.customHandlers.forEach((handler) => {
+      registry.registerHandler(handler);
+    });
+  }
+
+  fastify.decorate("webSocketRegistry", registry);
+
   fastify.server.on("upgrade", async (request, socket, head) => {
     fastify.log.info("Upgrading browser socket...");
     const url = request.url ?? "";
-    const params = Object.fromEntries(new URL(url || "", `http://${request.headers.host}`).searchParams.entries());
+    const params = Object.fromEntries(
+      new URL(url || "", `http://${request.headers.host}`).searchParams.entries(),
+    );
 
-    switch (true) {
-      case url.startsWith("/v1/sessions/logs"):
-        fastify.log.info("Connecting to logs...");
-        wss.handleUpgrade(request, socket, head, (ws) => handleLogsWebSocket(fastify, ws));
-        break;
+    const context: WebSocketHandlerContext = {
+      fastify,
+      wss,
+      params,
+    };
 
-      case url.startsWith("/v1/sessions/cast"):
-        fastify.log.info("Connecting to cast...");
-        await handleCastSession(request, socket, head, wss, fastify.sessionService, params);
-        break;
+    const handler = registry.matchHandler(url);
 
-      case url.startsWith("/v1/sessions/pageId"):
-        fastify.log.info("Connecting to pageId...");
-        wss.handleUpgrade(request, socket, head, (ws) => {
-          const messageHandler = (payload: { pageId: string }) => {
-            if (ws.readyState === WebSocket.OPEN) {
-              ws.send(JSON.stringify(payload));
-            }
-          };
-
-          fastify.cdpService.on(`pageId`, messageHandler);
-
-          ws.on("error", (err) => {
-            fastify.log.error("PageId WebSocket error:", err);
-          });
-
-          ws.on("close", () => {
-            fastify.log.info("PageId WebSocket connection closed");
-            fastify.cdpService.removeListener(`pageId`, messageHandler);
-          });
-        });
-        break;
-
-      // Handle recording endpoint
-      case url.startsWith("/v1/sessions/recording"):
-        fastify.log.info("Connecting to recording events...");
-        wss.handleUpgrade(request, socket, head, (ws) => {
-          const messageHandler = (payload: { events: Record<string, any>[] }) => {
-            if (ws.readyState === WebSocket.OPEN) {
-              ws.send(JSON.stringify(payload.events));
-            }
-          };
-
-          fastify.cdpService.on(EmitEvent.Recording, messageHandler);
-
-          // TODO: handle inputs to browser from client
-          ws.on("message", async (message) => {});
-
-          ws.on("close", () => {
-            fastify.log.info("Recording WebSocket connection closed");
-            fastify.cdpService.removeListener(EmitEvent.Recording, messageHandler);
-          });
-
-          ws.on("error", (err) => {
-            fastify.log.error("Recording WebSocket error:", err);
-          });
-        });
-        break;
-
-      // Default route to CDP Service
-      default:
-        fastify.log.info("Connecting to CDP...");
-        try {
-          await fastify.cdpService.proxyWebSocket(request, socket, head);
-        } catch (err) {
-          fastify.log.error("CDP WebSocket error:", err);
-          socket.destroy();
-        }
-        break;
+    if (handler) {
+      try {
+        await handler.handler(request, socket, head, context);
+      } catch (err) {
+        fastify.log.error(`WebSocket handler error for ${url}:`, err);
+        socket.destroy();
+      }
+    } else {
+      fastify.log.info("Connecting to CDP...");
+      try {
+        await fastify.cdpService.proxyWebSocket(request, socket, head);
+      } catch (err) {
+        fastify.log.error("CDP WebSocket error:", err);
+        socket.destroy();
+      }
     }
   });
 };

--- a/api/src/plugins/browser-socket/handlers/cast.handler.ts
+++ b/api/src/plugins/browser-socket/handlers/cast.handler.ts
@@ -1,0 +1,24 @@
+import { IncomingMessage } from "http";
+import { Duplex } from "stream";
+import { WebSocketHandler, WebSocketHandlerContext } from "../../../types/websocket.js";
+import { handleCastSession } from "../casting.handler.js";
+
+export const castHandler: WebSocketHandler = {
+  path: "/v1/sessions/cast",
+  handler: async (
+    request: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    context: WebSocketHandlerContext,
+  ) => {
+    context.fastify.log.info("Connecting to cast...");
+    await handleCastSession(
+      request,
+      socket,
+      head,
+      context.wss,
+      context.fastify.sessionService,
+      context.params,
+    );
+  },
+};

--- a/api/src/plugins/browser-socket/handlers/index.ts
+++ b/api/src/plugins/browser-socket/handlers/index.ts
@@ -1,0 +1,17 @@
+export { logsHandler } from "./logs.handler.js";
+export { castHandler } from "./cast.handler.js";
+export { pageIdHandler } from "./pageId.handler.js";
+export { recordingHandler } from "./recording.handler.js";
+
+import { WebSocketHandler } from "../../../types/websocket.js";
+import { logsHandler } from "./logs.handler.js";
+import { castHandler } from "./cast.handler.js";
+import { pageIdHandler } from "./pageId.handler.js";
+import { recordingHandler } from "./recording.handler.js";
+
+export const defaultHandlers: WebSocketHandler[] = [
+  logsHandler,
+  castHandler,
+  pageIdHandler,
+  recordingHandler,
+];

--- a/api/src/plugins/browser-socket/handlers/logs.handler.ts
+++ b/api/src/plugins/browser-socket/handlers/logs.handler.ts
@@ -1,0 +1,39 @@
+import { IncomingMessage } from "http";
+import { Duplex } from "stream";
+import { WebSocket } from "ws";
+import { EmitEvent } from "../../../types/enums.js";
+import { WebSocketHandler, WebSocketHandlerContext } from "../../../types/websocket.js";
+
+function handleLogsWebSocket(context: WebSocketHandlerContext, ws: WebSocket) {
+  const { fastify } = context;
+
+  const messageHandler = (payload: { pageId: string }) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify([payload]));
+    }
+  };
+
+  fastify.cdpService.on(EmitEvent.Log, messageHandler);
+
+  ws.on("error", (err) => {
+    fastify.log.error("Logs WebSocket error:", err);
+  });
+
+  ws.on("close", () => {
+    fastify.log.info("Logs WebSocket connection closed");
+    fastify.cdpService.removeListener("log", messageHandler);
+  });
+}
+
+export const logsHandler: WebSocketHandler = {
+  path: "/v1/sessions/logs",
+  handler: (
+    request: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    context: WebSocketHandlerContext,
+  ) => {
+    context.fastify.log.info("Connecting to logs...");
+    context.wss.handleUpgrade(request, socket, head, (ws) => handleLogsWebSocket(context, ws));
+  },
+};

--- a/api/src/plugins/browser-socket/handlers/pageId.handler.ts
+++ b/api/src/plugins/browser-socket/handlers/pageId.handler.ts
@@ -1,0 +1,38 @@
+import { IncomingMessage } from "http";
+import { Duplex } from "stream";
+import { WebSocket } from "ws";
+import { WebSocketHandler, WebSocketHandlerContext } from "../../../types/websocket.js";
+
+function handlePageIdWebSocket(context: WebSocketHandlerContext, ws: WebSocket) {
+  const { fastify } = context;
+
+  const messageHandler = (payload: { pageId: string }) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(payload));
+    }
+  };
+
+  fastify.cdpService.on("pageId", messageHandler);
+
+  ws.on("error", (err) => {
+    fastify.log.error("PageId WebSocket error:", err);
+  });
+
+  ws.on("close", () => {
+    fastify.log.info("PageId WebSocket connection closed");
+    fastify.cdpService.removeListener("pageId", messageHandler);
+  });
+}
+
+export const pageIdHandler: WebSocketHandler = {
+  path: "/v1/sessions/pageId",
+  handler: (
+    request: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    context: WebSocketHandlerContext,
+  ) => {
+    context.fastify.log.info("Connecting to pageId...");
+    context.wss.handleUpgrade(request, socket, head, (ws) => handlePageIdWebSocket(context, ws));
+  },
+};

--- a/api/src/plugins/browser-socket/handlers/recording.handler.ts
+++ b/api/src/plugins/browser-socket/handlers/recording.handler.ts
@@ -1,0 +1,42 @@
+import { IncomingMessage } from "http";
+import { Duplex } from "stream";
+import { WebSocket } from "ws";
+import { EmitEvent } from "../../../types/enums.js";
+import { WebSocketHandler, WebSocketHandlerContext } from "../../../types/websocket.js";
+
+function handleRecordingWebSocket(context: WebSocketHandlerContext, ws: WebSocket) {
+  const { fastify } = context;
+
+  const messageHandler = (payload: { events: Record<string, any>[] }) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(payload.events));
+    }
+  };
+
+  fastify.cdpService.on(EmitEvent.Recording, messageHandler);
+
+  // TODO: handle inputs to browser from client
+  ws.on("message", async (message) => {});
+
+  ws.on("close", () => {
+    fastify.log.info("Recording WebSocket connection closed");
+    fastify.cdpService.removeListener(EmitEvent.Recording, messageHandler);
+  });
+
+  ws.on("error", (err) => {
+    fastify.log.error("Recording WebSocket error:", err);
+  });
+}
+
+export const recordingHandler: WebSocketHandler = {
+  path: "/v1/sessions/recording",
+  handler: (
+    request: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    context: WebSocketHandlerContext,
+  ) => {
+    context.fastify.log.info("Connecting to recording events...");
+    context.wss.handleUpgrade(request, socket, head, (ws) => handleRecordingWebSocket(context, ws));
+  },
+};

--- a/api/src/services/websocket-registry.service.ts
+++ b/api/src/services/websocket-registry.service.ts
@@ -1,0 +1,24 @@
+import { WebSocketHandler, WebSocketHandlerRegistry } from "../types/websocket.js";
+
+export class WebSocketRegistryService implements WebSocketHandlerRegistry {
+  public handlers = new Map<string, WebSocketHandler>();
+
+  registerHandler(handler: WebSocketHandler): void {
+    this.handlers.set(handler.path, handler);
+  }
+
+  getHandler(path: string): WebSocketHandler | undefined {
+    return this.handlers.get(path);
+  }
+
+  matchHandler(url: string): WebSocketHandler | undefined {
+    // TODO: use path-to-regexp or find-my-way to match the path
+    // Find the first handler whose path matches the start of the URL
+    for (const [path, handler] of this.handlers.entries()) {
+      if (url.startsWith(path)) {
+        return handler;
+      }
+    }
+    return undefined;
+  }
+}

--- a/api/src/types/index.ts
+++ b/api/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./enums.js";
 export * from "./browser.js";
+export * from "./websocket.js";

--- a/api/src/types/websocket.ts
+++ b/api/src/types/websocket.ts
@@ -1,0 +1,27 @@
+import { IncomingMessage } from "http";
+import { Duplex } from "stream";
+import { WebSocketServer } from "ws";
+import { FastifyInstance } from "fastify";
+
+export interface WebSocketHandlerContext {
+  fastify: FastifyInstance;
+  wss: WebSocketServer;
+  params: Record<string, string>;
+}
+
+export interface WebSocketHandler {
+  path: string;
+  handler: (
+    request: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    context: WebSocketHandlerContext,
+  ) => Promise<void> | void;
+}
+
+export interface WebSocketHandlerRegistry {
+  handlers: Map<string, WebSocketHandler>;
+  registerHandler: (handler: WebSocketHandler) => void;
+  getHandler: (path: string) => WebSocketHandler | undefined;
+  matchHandler: (url: string) => WebSocketHandler | undefined;
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -16,12 +16,13 @@ export default defineConfig({
       "/api": {
         target: "http://localhost:3000",
         changeOrigin: true,
-        rewrite: path => path.replace(/^\/api/, ""),
+        rewrite: (path) => path.replace(/^\/api/, ""),
       },
       "/ws": {
         target: "ws://localhost:3000",
         ws: true,
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/ws/, ""),
       },
     },
   },


### PR DESCRIPTION
This pull request refactors the WebSocket handling in the browser-socket plugin by introducing a registry-based approach for managing WebSocket handlers. It modularizes the codebase, improves maintainability, and adds support for custom WebSocket handlers. Below is a summary of the key changes:

### Refactoring WebSocket Handling

* Introduced a `WebSocketRegistryService` to manage WebSocket handlers, allowing dynamic registration and matching of handlers based on URL paths. (`api/src/services/websocket-registry.service.ts`, [api/src/services/websocket-registry.service.tsR1-R24](diffhunk://#diff-e2bde7786f0f59aee87859ba8d640929daf83cccf1cf76f11446e0ccbdac4b7dR1-R24))
* Replaced hardcoded WebSocket routing logic with a registry-based approach in the `browser-socket` plugin. This enables cleaner and more scalable WebSocket management. (`api/src/plugins/browser-socket/browser-socket.ts`, [api/src/plugins/browser-socket/browser-socket.tsL3-L110](diffhunk://#diff-31a914dc578fd63d5ade2657ef2f0814a9b4b12358d9a472370ede5b1232cd55L3-L110))

### Modularization of WebSocket Handlers

* Created separate handler modules for `logs`, `cast`, `pageId`, and `recording` WebSocket endpoints, each encapsulating its specific logic. (`api/src/plugins/browser-socket/handlers/*.handler.ts`, [[1]](diffhunk://#diff-aa202564db258cacf11cadc9742ead9b92b747dfc8396b8e1af9ddc7703eb252R1-R24) [[2]](diffhunk://#diff-2461b1e12101f63255b38e9385d3f696e15fd844611fb8ae2cf15cc29be7aaddR1-R39) [[3]](diffhunk://#diff-182c014dd00d21f824c4cb327f2a38a451769150b9f9213c849262991420f557R1-R38) [[4]](diffhunk://#diff-f4f410c933b41153333f944595eb3b24ea9c0cbb0616b749b98a91b87c507ba5R1-R42)
* Consolidated all default handlers into a single `defaultHandlers` array for streamlined registration. (`api/src/plugins/browser-socket/handlers/index.ts`, [api/src/plugins/browser-socket/handlers/index.tsR1-R17](diffhunk://#diff-5addff18a437c47f54feeafc9825d509c7c8c5ed342b2484b556fef58d7739eaR1-R17))

### Enhancements to Plugin Configuration

* Added support for passing custom WebSocket handlers via the `SteelBrowserConfig` options, allowing extensibility. (`api/src/steel-browser-plugin.ts`, [[1]](diffhunk://#diff-4a47af253ed2c3765b1b1b61774c1f13776d6114b8f456ab1af3627f28fa11abR18-R38) [[2]](diffhunk://#diff-4a47af253ed2c3765b1b1b61774c1f13776d6114b8f456ab1af3627f28fa11abL49-R57)
* Updated the Fastify instance declaration to include the `webSocketRegistry` decorator. (`api/src/steel-browser-plugin.ts`, [api/src/steel-browser-plugin.tsR18-R38](diffhunk://#diff-4a47af253ed2c3765b1b1b61774c1f13776d6114b8f456ab1af3627f28fa11abR18-R38))

### Type Definitions for WebSocket Architecture

* Defined new types (`WebSocketHandler`, `WebSocketHandlerContext`, and `WebSocketHandlerRegistry`) to standardize the structure and behavior of WebSocket handlers. (`api/src/types/websocket.ts`, [api/src/types/websocket.tsR1-R27](diffhunk://#diff-66dc32465ab2259cbf7a11fde2f2a8b80c2a21131a32105d1ad0084cd98f71a2R1-R27))
* Exported the new WebSocket-related types for use across the codebase. (`api/src/types/index.ts`, [api/src/types/index.tsR3](diffhunk://#diff-b07d105b68f41879ad6bdf337c8fb33ac6623778f22e5e95132da6ed1d6315b0R3))

### Minor Updates

* Updated the `vite.config.ts` to include a rewrite rule for WebSocket paths in the development proxy configuration. (`ui/vite.config.ts`, [ui/vite.config.tsL19-R25](diffhunk://#diff-3ac010a0a7c98e20e2a93940f788480b80115f74ebbe72c7254b3e3bcdbc3c8eL19-R25))