### PR TITLE
feat: add onSessionEnd hook to plugin manager

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -1133,8 +1133,9 @@ export class CDPService extends EventEmitter {
   @traceable
   public async endSession(): Promise<void> {
     this.logger.info("Ending current session and restarting with default configuration.");
+    const sessionConfig = this.currentSessionConfig!;
     await this.shutdown();
-    await this.pluginManager.onSessionEnd(this.currentSessionConfig!);
+    await this.pluginManager.onSessionEnd(sessionConfig);
     this.currentSessionConfig = null;
     this.trackedOrigins.clear(); // Clear tracked origins
     await this.launch(this.defaultLaunchConfig);
@@ -1155,7 +1156,9 @@ export class CDPService extends EventEmitter {
       await this.launch(this.defaultLaunchConfig);
     } else {
       this.logger.info("Shutting down browser.");
+      const sessionConfig = this.currentSessionConfig!;
       await this.shutdown();
+      await this.pluginManager.onSessionEnd(sessionConfig);
     }
   }
 

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -1134,6 +1134,7 @@ export class CDPService extends EventEmitter {
   public async endSession(): Promise<void> {
     this.logger.info("Ending current session and restarting with default configuration.");
     await this.shutdown();
+    await this.pluginManager.onSessionEnd(this.currentSessionConfig!);
     this.currentSessionConfig = null;
     this.trackedOrigins.clear(); // Clear tracked origins
     await this.launch(this.defaultLaunchConfig);

--- a/api/src/services/cdp/plugins/core/base-plugin.ts
+++ b/api/src/services/cdp/plugins/core/base-plugin.ts
@@ -1,5 +1,6 @@
 import type { Browser, Page } from "puppeteer-core";
 import type { CDPService } from "../../cdp.service.js";
+import { BrowserLauncherOptions } from "../../../../types/browser.js";
 
 export interface PluginOptions {
   name: string;
@@ -29,4 +30,5 @@ export abstract class BasePlugin {
   public async onBrowserClose(browser: Browser): Promise<void> {}
   public async onBeforePageClose(page: Page): Promise<void> {}
   public async onShutdown(): Promise<void> {}
+  public async onSessionEnd(sessionConfig: BrowserLauncherOptions): Promise<void> {}
 }

--- a/api/src/services/cdp/plugins/core/plugin-manager.ts
+++ b/api/src/services/cdp/plugins/core/plugin-manager.ts
@@ -2,6 +2,7 @@ import { Browser, Page } from "puppeteer-core";
 import { CDPService } from "../../cdp.service.js";
 import { BasePlugin } from "./base-plugin.js";
 import { FastifyBaseLogger } from "fastify";
+import { BrowserLauncherOptions } from "../../../../types/browser.js";
 
 export class PluginManager {
   private plugins: Map<string, BasePlugin>;
@@ -140,6 +141,20 @@ export class PluginManager {
         await plugin.onShutdown();
       } catch (error) {
         this.logger.error(`Error in plugin ${plugin.name}.onShutdown: ${error}`);
+      }
+    });
+    await Promise.all(promises);
+  }
+
+  /**
+   * Notify all plugins when a session has ended
+   */
+  public async onSessionEnd(sessionConfig: BrowserLauncherOptions): Promise<void> {
+    const promises = Array.from(this.plugins.values()).map(async (plugin) => {
+      try {
+        await plugin.onSessionEnd(sessionConfig);
+      } catch (error) {
+        this.logger.error(`Error in plugin ${plugin.name}.onSessionEnd: ${error}`);
       }
     });
     await Promise.all(promises);


### PR DESCRIPTION
Extends the plugin manager to add a `onSessionEnd` hook which gets called when the session gets ended externally or the connection disconnects. This is different to the `onShutdown` as this can get called during the cleanup phase when starting a new session