### PR TITLE
Fix: Session recording bug when using proxies

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -66,7 +66,6 @@
     "fingerprint-generator": "2.1.62",
     "fingerprint-injector": "2.1.62",
     "http-proxy": "^1.18.1",
-    "http-proxy-3": "^1.20.5",
     "https-proxy-agent": "^7.0.6",
     "iconv-lite": "^0.6.3",
     "jsdom": "^26.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -66,6 +66,7 @@
     "fingerprint-generator": "2.1.62",
     "fingerprint-injector": "2.1.62",
     "http-proxy": "^1.18.1",
+    "http-proxy-3": "^1.20.5",
     "https-proxy-agent": "^7.0.6",
     "iconv-lite": "^0.6.3",
     "jsdom": "^26.0.0",

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -173,7 +173,8 @@ async function routes(server: FastifyInstance) {
     const contentType = req.headers['content-type'];
     const transferEncoding = req.headers['transfer-encoding'];
 
-    server.log.warn(`Parsing body from: ${req.url} with content-type: ${contentType}, transfer-encoding: ${transferEncoding}`);
+    server.log.warn(`Received body buffer of length: ${body?.length}`);
+    server.log.warn(`Headers: content-type=${contentType}, transfer-encoding=${transferEncoding}`);
 
     try {
       const json = JSON.parse(body.toString('utf8'));

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -154,18 +154,33 @@ async function routes(server: FastifyInstance) {
     async (request: SessionStreamRequest, reply: FastifyReply) => handleGetSessionStream(server, request, reply),
   );
 
-  server.addContentTypeParser('*', { parseAs: 'string' }, (req, body, done) => {
+  // server.addContentTypeParser('*', { parseAs: 'string' }, (req, body, done) => {
+  //   const contentType = req.headers['content-type'];
+  //   const transferEncoding = req.headers['transfer-encoding'];
+
+  //   server.log.warn(`Parsing body with content-type: ${contentType}, transfer-encoding: ${transferEncoding}`);
+
+  //   try {
+  //     const parsed = JSON.parse(body as string);
+  //     done(null, parsed);
+  //   } catch (err) {
+  //     server.log.error(`Failed to parse JSON body with content-type: ${contentType}, transfer-encoding: ${transferEncoding}`);
+  //     done(null, body); // fallback — pass raw string to route
+  //   }
+  // });
+
+  server.addContentTypeParser('*', { parseAs: 'buffer' }, (req, body, done) => {
     const contentType = req.headers['content-type'];
     const transferEncoding = req.headers['transfer-encoding'];
 
-    server.log.warn(`Parsing body with content-type: ${contentType}, transfer-encoding: ${transferEncoding}`);
+    server.log.warn(`Parsing body from: ${req.url} with content-type: ${contentType}, transfer-encoding: ${transferEncoding}`);
 
     try {
-      const parsed = JSON.parse(body as string);
-      done(null, parsed);
+      const json = JSON.parse(body.toString('utf8'));
+      done(null, json);
     } catch (err) {
-      server.log.error(`Failed to parse JSON body with content-type: ${contentType}, transfer-encoding: ${transferEncoding}`);
-      done(null, body); // fallback — pass raw string to route
+      server.log.error({ err }, `JSON parse failed: ${(err as any)?.message}`);
+      done(null, body); // fallback
     }
   });
   

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -153,7 +153,7 @@ async function routes(server: FastifyInstance) {
     },
     async (request: SessionStreamRequest, reply: FastifyReply) => handleGetSessionStream(server, request, reply),
   );
-  
+
   server.post(
     "/events",
     {
@@ -166,7 +166,6 @@ async function routes(server: FastifyInstance) {
       },
     },
     async (request: FastifyRequest<{ Body: RecordedEvents }>, reply: FastifyReply) => {
-      server.log.warn("Passing events to custom emit");
       server.cdpService.customEmit(EmitEvent.Recording, request.body);
       return reply.send({ status: "ok" });
     },

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -173,8 +173,8 @@ async function routes(server: FastifyInstance) {
     const contentType = req.headers['content-type'];
     const transferEncoding = req.headers['transfer-encoding'];
 
-    server.log.warn(`Received body buffer of length: ${body?.length}`);
-    server.log.warn(`Headers: content-type=${contentType}, transfer-encoding=${transferEncoding}`);
+    console.error(`Received body buffer of length: ${body?.length}`);
+    console.error(`Headers: content-type=${contentType}, transfer-encoding=${transferEncoding}`);
 
     try {
       const json = JSON.parse(body.toString('utf8'));

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -154,6 +154,21 @@ async function routes(server: FastifyInstance) {
     async (request: SessionStreamRequest, reply: FastifyReply) => handleGetSessionStream(server, request, reply),
   );
 
+  server.addContentTypeParser('*', { parseAs: 'string' }, (req, body, done) => {
+    const contentType = req.headers['content-type'];
+    const transferEncoding = req.headers['transfer-encoding'];
+
+    server.log.warn(`Parsing body with content-type: ${contentType}, transfer-encoding: ${transferEncoding}`);
+
+    try {
+      const parsed = JSON.parse(body as string);
+      done(null, parsed);
+    } catch (err) {
+      server.log.error(`Failed to parse JSON body with content-type: ${contentType}, transfer-encoding: ${transferEncoding}`);
+      done(null, body); // fallback — pass raw string to route
+    }
+  });
+  
   // server.post(
   //   "/events",
   //   {

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -154,31 +154,47 @@ async function routes(server: FastifyInstance) {
     async (request: SessionStreamRequest, reply: FastifyReply) => handleGetSessionStream(server, request, reply),
   );
 
-  server.post(
-    "/events",
-    {
-      preParsing: async (req, reply, payload) => {
-        server.log.warn(
-          `Incoming headers: ${Object.entries(req.headers)
-            .map(([key, val]) => `${key}=${Array.isArray(val) ? val.join(",") : val}`)
-            .join(" ")}`
-        );
-        return payload;
-      },
-      schema: {
-        operationId: "receive_events",
-        description: "Receive recorded events from the browser",
-        tags: ["Sessions"],
-        summary: "Receive recorded events from the browser",
-        body: $ref("RecordedEvents"),
-      },
-    },
-    async (request: FastifyRequest<{ Body: RecordedEvents }>, reply: FastifyReply) => {
-      server.log.warn("Passing events to custom emit");
-      server.cdpService.customEmit(EmitEvent.Recording, request.body);
+  // server.post(
+  //   "/events",
+  //   {
+  //     preParsing: async (req, reply, payload) => {
+  //       server.log.warn(
+  //         `Incoming headers: ${Object.entries(req.headers)
+  //           .map(([key, val]) => `${key}=${Array.isArray(val) ? val.join(",") : val}`)
+  //           .join(" ")}`
+  //       );
+  //       return payload;
+  //     },
+  //     schema: {
+  //       operationId: "receive_events",
+  //       description: "Receive recorded events from the browser",
+  //       tags: ["Sessions"],
+  //       summary: "Receive recorded events from the browser",
+  //       body: $ref("RecordedEvents"),
+  //     },
+  //   },
+  //   async (request: FastifyRequest<{ Body: RecordedEvents }>, reply: FastifyReply) => {
+  //     server.log.warn("Passing events to custom emit");
+  //     server.cdpService.customEmit(EmitEvent.Recording, request.body);
+  //     return reply.send({ status: "ok" });
+  //   },
+  // );
+
+  server.post("/events", async (req, reply) => {
+    const chunks: any[] = [];
+    for await (const chunk of req.raw) chunks.push(chunk);
+    const raw = Buffer.concat(chunks).toString("utf8");
+
+    try {
+      const parsed = JSON.parse(raw);
+      server.log.warn("Parsed /events body:", parsed);
+      server.cdpService.customEmit(EmitEvent.Recording, parsed);
       return reply.send({ status: "ok" });
-    },
-  );
+    } catch (err) {
+      server.log.error({ err }, "JSON parse error in /events:");
+      return reply.code(400).send({ error: "Invalid JSON" });
+    }
+  });
 
   server.get(
     "/sessions/:id/live-details",

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -169,57 +169,57 @@ async function routes(server: FastifyInstance) {
   //   }
   // });
 
-  server.addContentTypeParser('*', { parseAs: 'buffer' }, (req, body, done) => {
-    const contentType = req.headers['content-type'];
-    const transferEncoding = req.headers['transfer-encoding'];
+  // server.addContentTypeParser('*', { parseAs: 'buffer' }, (req, body, done) => {
+  //   const contentType = req.headers['content-type'];
+  //   const transferEncoding = req.headers['transfer-encoding'];
 
-    console.error(`Received body buffer of length: ${body?.length}`);
-    console.error(`Headers: content-type=${contentType}, transfer-encoding=${transferEncoding}`);
+  //   console.error(`Received body buffer of length: ${body?.length}`);
+  //   console.error(`Headers: content-type=${contentType}, transfer-encoding=${transferEncoding}`);
 
-    try {
-      const json = JSON.parse(body.toString('utf8'));
-      done(null, json);
-    } catch (err) {
-      server.log.error({ err }, `JSON parse failed: ${(err as any)?.message}`);
-      done(null, body); // fallback
-    }
-  });
+  //   try {
+  //     const json = JSON.parse(body.toString('utf8'));
+  //     done(null, json);
+  //   } catch (err) {
+  //     server.log.error({ err }, `JSON parse failed: ${(err as any)?.message}`);
+  //     done(null, body); // fallback
+  //   }
+  // });
   
-  // server.post(
-  //   "/events",
-  //   {
-  //     preParsing: async (req, reply, payload) => {
-  //       server.log.warn(
-  //         `Incoming headers: ${Object.entries(req.headers)
-  //           .map(([key, val]) => `${key}=${Array.isArray(val) ? val.join(",") : val}`)
-  //           .join(" ")}`
-  //       );
-  //       return payload;
-  //     },
-  //     schema: {
-  //       operationId: "receive_events",
-  //       description: "Receive recorded events from the browser",
-  //       tags: ["Sessions"],
-  //       summary: "Receive recorded events from the browser",
-  //       body: $ref("RecordedEvents"),
-  //     },
-  //   },
-  //   async (request: FastifyRequest<{ Body: RecordedEvents }>, reply: FastifyReply) => {
-  //     server.log.warn("Passing events to custom emit");
-  //     server.cdpService.customEmit(EmitEvent.Recording, request.body);
-  //     return reply.send({ status: "ok" });
-  //   },
-  // );
-
-  server.post("/events", async (req, reply) => {
-    try {
-      server.cdpService.customEmit(EmitEvent.Recording, req.body);
+  server.post(
+    "/events",
+    {
+      preParsing: async (req, reply, payload) => {
+        server.log.warn(
+          `Incoming headers: ${Object.entries(req.headers)
+            .map(([key, val]) => `${key}=${Array.isArray(val) ? val.join(",") : val}`)
+            .join(" ")}`
+        );
+        return payload;
+      },
+      schema: {
+        operationId: "receive_events",
+        description: "Receive recorded events from the browser",
+        tags: ["Sessions"],
+        summary: "Receive recorded events from the browser",
+        body: $ref("RecordedEvents"),
+      },
+    },
+    async (request: FastifyRequest<{ Body: RecordedEvents }>, reply: FastifyReply) => {
+      server.log.warn("Passing events to custom emit");
+      server.cdpService.customEmit(EmitEvent.Recording, request.body);
       return reply.send({ status: "ok" });
-    } catch (err) {
-      server.log.error({ err }, "JSON parse error in /events:");
-      return reply.code(400).send({ error: "Invalid JSON" });
-    }
-  });
+    },
+  );
+
+  // server.post("/events", async (req, reply) => {
+  //   try {
+  //     server.cdpService.customEmit(EmitEvent.Recording, req.body);
+  //     return reply.send({ status: "ok" });
+  //   } catch (err) {
+  //     server.log.error({ err }, "JSON parse error in /events:");
+  //     return reply.code(400).send({ error: "Invalid JSON" });
+  //   }
+  // });
 
   server.get(
     "/sessions/:id/live-details",

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -153,49 +153,10 @@ async function routes(server: FastifyInstance) {
     },
     async (request: SessionStreamRequest, reply: FastifyReply) => handleGetSessionStream(server, request, reply),
   );
-
-  // server.addContentTypeParser('*', { parseAs: 'string' }, (req, body, done) => {
-  //   const contentType = req.headers['content-type'];
-  //   const transferEncoding = req.headers['transfer-encoding'];
-
-  //   server.log.warn(`Parsing body with content-type: ${contentType}, transfer-encoding: ${transferEncoding}`);
-
-  //   try {
-  //     const parsed = JSON.parse(body as string);
-  //     done(null, parsed);
-  //   } catch (err) {
-  //     server.log.error(`Failed to parse JSON body with content-type: ${contentType}, transfer-encoding: ${transferEncoding}`);
-  //     done(null, body); // fallback — pass raw string to route
-  //   }
-  // });
-
-  // server.addContentTypeParser('*', { parseAs: 'buffer' }, (req, body, done) => {
-  //   const contentType = req.headers['content-type'];
-  //   const transferEncoding = req.headers['transfer-encoding'];
-
-  //   console.error(`Received body buffer of length: ${body?.length}`);
-  //   console.error(`Headers: content-type=${contentType}, transfer-encoding=${transferEncoding}`);
-
-  //   try {
-  //     const json = JSON.parse(body.toString('utf8'));
-  //     done(null, json);
-  //   } catch (err) {
-  //     server.log.error({ err }, `JSON parse failed: ${(err as any)?.message}`);
-  //     done(null, body); // fallback
-  //   }
-  // });
   
   server.post(
     "/events",
     {
-      preParsing: async (req, reply, payload) => {
-        server.log.warn(
-          `Incoming headers: ${Object.entries(req.headers)
-            .map(([key, val]) => `${key}=${Array.isArray(val) ? val.join(",") : val}`)
-            .join(" ")}`
-        );
-        return payload;
-      },
       schema: {
         operationId: "receive_events",
         description: "Receive recorded events from the browser",
@@ -210,16 +171,6 @@ async function routes(server: FastifyInstance) {
       return reply.send({ status: "ok" });
     },
   );
-
-  // server.post("/events", async (req, reply) => {
-  //   try {
-  //     server.cdpService.customEmit(EmitEvent.Recording, req.body);
-  //     return reply.send({ status: "ok" });
-  //   } catch (err) {
-  //     server.log.error({ err }, "JSON parse error in /events:");
-  //     return reply.code(400).send({ error: "Invalid JSON" });
-  //   }
-  // });
 
   server.get(
     "/sessions/:id/live-details",

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -157,6 +157,10 @@ async function routes(server: FastifyInstance) {
   server.post(
     "/events",
     {
+      preParsing: async (req, reply, payload) => {
+        server.log.warn("Incoming headers:", req.headers);
+        return payload;
+      },
       schema: {
         operationId: "receive_events",
         description: "Receive recorded events from the browser",

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -166,6 +166,7 @@ async function routes(server: FastifyInstance) {
       },
     },
     async (request: FastifyRequest<{ Body: RecordedEvents }>, reply: FastifyReply) => {
+      server.log.warn("Passing events to custom emit");
       server.cdpService.customEmit(EmitEvent.Recording, request.body);
       return reply.send({ status: "ok" });
     },

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -158,7 +158,11 @@ async function routes(server: FastifyInstance) {
     "/events",
     {
       preParsing: async (req, reply, payload) => {
-        server.log.warn("Incoming headers:", req.headers);
+        server.log.warn(
+          `Incoming headers: ${Object.entries(req.headers)
+            .map(([key, val]) => `${key}=${Array.isArray(val) ? val.join(",") : val}`)
+            .join(" ")}`
+        );
         return payload;
       },
       schema: {

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -212,14 +212,8 @@ async function routes(server: FastifyInstance) {
   // );
 
   server.post("/events", async (req, reply) => {
-    const chunks: any[] = [];
-    for await (const chunk of req.raw) chunks.push(chunk);
-    const raw = Buffer.concat(chunks).toString("utf8");
-
     try {
-      const parsed = JSON.parse(raw);
-      server.log.warn("Parsed /events body:", parsed);
-      server.cdpService.customEmit(EmitEvent.Recording, parsed);
+      server.cdpService.customEmit(EmitEvent.Recording, req.body);
       return reply.send({ status: "ok" });
     } catch (err) {
       server.log.error({ err }, "JSON parse error in /events:");

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -1098,9 +1098,9 @@ export class CDPService extends EventEmitter {
     }
   }
 
-private async logEvent(event: BrowserEvent) {
+  private async logEvent(event: BrowserEvent) {
     if (!this.launchConfig?.logSinkUrl) return;
-    
+
     try {
       const response = await fetch(this.launchConfig.logSinkUrl, {
         method: "POST",

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -215,7 +215,7 @@ export class CDPService extends EventEmitter {
         });
       }
     } catch (error) {
-      this.logger.error(`Error emitting event: ${error}`);
+      this.logger.error({ err: error }, `Error emitting event`);
     }
   }
 

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -1099,18 +1099,7 @@ export class CDPService extends EventEmitter {
   }
 
 private async logEvent(event: BrowserEvent) {
-    if (!this.launchConfig?.logSinkUrl) {
-      this.logger.error({ session: this.launchConfig?.extra?.session }, "Error logging event, missing logSinkUrl");
-      return;
-    }
-    
-    const u = new URL(this.launchConfig?.logSinkUrl);
-    const parts = u.pathname.split("/");
-    const sessionId = parts.at(-1);
-    const orgId = u.searchParams.get("orgId");
-
-    this.logger.warn({ sessionId, orgId }, "LogEvent for session")
-    console.error(`\x1b[1m\x1b[91m Log event for session { sessionId: "${sessionId}", orgId: "${orgId}" }\x1b[0m`);
+    if (!this.launchConfig?.logSinkUrl) return;
     
     try {
       const response = await fetch(this.launchConfig.logSinkUrl, {

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -1110,7 +1110,7 @@ private async logEvent(event: BrowserEvent) {
     const orgId = u.searchParams.get("orgId");
 
     this.logger.warn({ sessionId, orgId }, "LogEvent for session")
-    console.log(`\x1b[1m\x1b[91m{ sessionId: "${sessionId}", orgId: "${orgId}" }\x1b[0m`);
+    console.error(`\x1b[1m\x1b[91m Log event for session { sessionId: "${sessionId}", orgId: "${orgId}" }\x1b[0m`);
     
     try {
       const response = await fetch(this.launchConfig.logSinkUrl, {

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -1098,9 +1098,20 @@ export class CDPService extends EventEmitter {
     }
   }
 
-  private async logEvent(event: BrowserEvent) {
-    if (!this.launchConfig?.logSinkUrl) return;
+private async logEvent(event: BrowserEvent) {
+    if (!this.launchConfig?.logSinkUrl) {
+      this.logger.error({ session: this.launchConfig?.extra?.session }, "Error logging event, missing logSinkUrl");
+      return;
+    }
+    
+    const u = new URL(this.launchConfig?.logSinkUrl);
+    const parts = u.pathname.split("/");
+    const sessionId = parts.at(-1);
+    const orgId = u.searchParams.get("orgId");
 
+    this.logger.warn({ sessionId, orgId }, "LogEvent for session")
+    console.log(`\x1b[1m\x1b[91m{ sessionId: "${sessionId}", orgId: "${orgId}" }\x1b[0m`);
+    
     try {
       const response = await fetch(this.launchConfig.logSinkUrl, {
         method: "POST",

--- a/api/src/utils/passthough-proxy.ts
+++ b/api/src/utils/passthough-proxy.ts
@@ -17,7 +17,10 @@ const hopByHopHeaders = [
  * There's an issue with proxy-chain's implementation causing corruption in our internals requests
  */
 export const PassthroughServer = http.createServer((clientReq, clientRes) => {
-  console.error("Incoming clientReq.headers:", clientReq.headers);
+  const headerString = `{ ${Object.entries(clientReq.headers)
+    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+    .join(", ")} }`;
+  console.error(`Incoming clientReq.headers: ${headerString}`);
 
   const targetUrl = new URL(clientReq.url ?? "/", `http://${clientReq.headers.host}`);
 
@@ -34,7 +37,10 @@ export const PassthroughServer = http.createServer((clientReq, clientRes) => {
   proxyHeaders['x-forwarded-proto'] = 'http';
   proxyHeaders['x-forwarded-host'] = clientReq.headers.host || '';
 
-  console.log("Forwarding headers to target:", proxyHeaders);
+  const forwardingHeaderString = `{ ${Object.entries(proxyHeaders)
+    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+    .join(", ")} }`;
+  console.error(`Forwarding headers to target: ${forwardingHeaderString}`);
 
   const proxyReq = http.request({
     method: clientReq.method,

--- a/api/src/utils/passthough-proxy.ts
+++ b/api/src/utils/passthough-proxy.ts
@@ -1,0 +1,67 @@
+import http, { IncomingHttpHeaders } from "node:http";
+
+// Headers that are hop-by-hop and should not be forwarded RFC 2616, Section 13.5.1
+const hopByHopHeaders = [
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailers',
+  'transfer-encoding',
+  'upgrade',
+];
+
+/**
+ * Creates a simple http proxy which reverse proxies the original request to the original host.
+ * There's an issue with proxy-chain's implementation causing corruption in our internals requests
+ */
+export const PassthroughServer = http.createServer((clientReq, clientRes) => {
+  const targetUrl = new URL(clientReq.url ?? "/", `http://${clientReq.headers.host}`);
+
+  const proxyHeaders: IncomingHttpHeaders = {};
+  for (const [key, value] of Object.entries(clientReq.headers)) {
+    if (!hopByHopHeaders.includes(key.toLowerCase())) {
+      proxyHeaders[key] = value;
+    }
+  }
+
+  proxyHeaders.host = targetUrl.host;
+
+  proxyHeaders['x-forwarded-for'] = clientReq.socket.remoteAddress || '';
+  proxyHeaders['x-forwarded-proto'] = 'http';
+  proxyHeaders['x-forwarded-host'] = clientReq.headers.host || '';
+
+  const proxyReq = http.request({
+    method: clientReq.method,
+    headers: proxyHeaders,
+    hostname: targetUrl.hostname,
+    port: targetUrl.port,
+    path: targetUrl.pathname + targetUrl.search,
+  }, (proxyRes) => {
+    const clientResHeaders = {};
+    for (const [key, value] of Object.entries(proxyRes.headers)) {
+      if (!hopByHopHeaders.includes(key.toLowerCase())) {
+        clientResHeaders[key] = value;
+      }
+    }
+    
+    clientRes.writeHead(proxyRes.statusCode ?? 500, clientResHeaders);
+    proxyRes.pipe(clientRes);
+  });
+
+  proxyReq.on("error", (err) => {
+    console.error(`Proxy error for ${targetUrl}:`, err);
+    if (!clientRes.headersSent) {
+      clientRes.writeHead(502);
+    }
+    clientRes.end("Proxy error: Could not connect to the target service.");
+  });
+
+  clientReq.on('error', (err) => {
+    console.error(`Client request error:`, err);
+    proxyReq.destroy();
+  });
+
+  clientReq.pipe(proxyReq);
+});

--- a/api/src/utils/passthough-proxy.ts
+++ b/api/src/utils/passthough-proxy.ts
@@ -17,20 +17,24 @@ const hopByHopHeaders = [
  * There's an issue with proxy-chain's implementation causing corruption in our internals requests
  */
 export const PassthroughServer = http.createServer((clientReq, clientRes) => {
+  console.error("Incoming clientReq.headers:", clientReq.headers);
+
   const targetUrl = new URL(clientReq.url ?? "/", `http://${clientReq.headers.host}`);
 
   const proxyHeaders: IncomingHttpHeaders = {};
   for (const [key, value] of Object.entries(clientReq.headers)) {
-    if (!hopByHopHeaders.includes(key.toLowerCase())) {
-      proxyHeaders[key] = value;
+    const lowerKey = key.toLowerCase();
+    if (!hopByHopHeaders.includes(lowerKey)) {
+      proxyHeaders[lowerKey] = value;
     }
   }
 
-  proxyHeaders.host = targetUrl.host;
-
+  proxyHeaders['host'] = targetUrl.host;
   proxyHeaders['x-forwarded-for'] = clientReq.socket.remoteAddress || '';
   proxyHeaders['x-forwarded-proto'] = 'http';
   proxyHeaders['x-forwarded-host'] = clientReq.headers.host || '';
+
+  console.log("Forwarding headers to target:", proxyHeaders);
 
   const proxyReq = http.request({
     method: clientReq.method,

--- a/api/src/utils/passthough-proxy.ts
+++ b/api/src/utils/passthough-proxy.ts
@@ -18,11 +18,6 @@ export const hopByHopHeaders = new Set([
  * There's an issue with proxy-chain's implementation causing corruption in our internals requests
  */
 export const PassthroughServer = http.createServer((clientReq, clientRes) => {
-  const headerString = `{ ${Object.entries(clientReq.headers)
-    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
-    .join(", ")} }`;
-  console.error(`Incoming clientReq.headers: ${headerString}`);
-
   const targetUrl = new URL(clientReq.url ?? "/", `http://${clientReq.headers.host}`);
 
   const proxyHeaders: IncomingHttpHeaders = {};
@@ -37,11 +32,6 @@ export const PassthroughServer = http.createServer((clientReq, clientRes) => {
   proxyHeaders['x-forwarded-for'] = clientReq.socket.remoteAddress || '';
   proxyHeaders['x-forwarded-proto'] = 'http';
   proxyHeaders['x-forwarded-host'] = clientReq.headers.host || '';
-
-  const forwardingHeaderString = `{ ${Object.entries(proxyHeaders)
-    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
-    .join(", ")} }`;
-  console.error(`Forwarding headers to target: ${forwardingHeaderString}`);
 
   const proxyReq = http.request({
     method: clientReq.method,

--- a/api/src/utils/proxy.ts
+++ b/api/src/utils/proxy.ts
@@ -18,8 +18,8 @@ export class ProxyServer extends Server {
         const isEventsPath = url.endsWith("/v1/events");
 
         if (isEventsPath) {
-          console.error("Bypassing /events request:");
-          console.log(`\x1b[1m\x1b[91m{ url: "${url}", hostname: "${hostname}" }\x1b[0m`);
+          console.error("Bypassing /events request:", url, hostname);
+          console.error(`\x1b[1m\x1b[91m{ url: "${url}", hostname: "${hostname}" }\x1b[0m`);
         }
 
         const internalBypassTests = new Set([

--- a/api/src/utils/proxy.ts
+++ b/api/src/utils/proxy.ts
@@ -13,7 +13,15 @@ export class ProxyServer extends Server {
     super({
       port: 0,
 
-      prepareRequestFunction: ({ connectionId, hostname }) => {
+      prepareRequestFunction: ({ connectionId, hostname, request }) => {
+        const url = request?.url ?? "";
+        const isEventsPath = url.endsWith("/v1/events");
+
+        if (isEventsPath) {
+          console.error("Bypassing /events request:");
+          console.log(`\x1b[1m\x1b[91m{ url: "${url}", hostname: "${hostname}" }\x1b[0m`);
+        }
+
         const internalBypassTests = new Set([
           "0.0.0.0",
           process.env.HOST,

--- a/api/src/utils/proxy.ts
+++ b/api/src/utils/proxy.ts
@@ -1,70 +1,74 @@
 import { env } from "../env.js";
 import { SessionService } from "../services/session.service.js";
-import { Server } from "proxy-chain";
+import http from "http";
+import { createProxyServer as coreCreateProxyServer } from "http-proxy-3";
 
-export class ProxyServer extends Server {
+export class ProxyServer {
   public url: string;
   public upstreamProxyUrl: string;
   public txBytes = 0;
   public rxBytes = 0;
-  private hostConnections = new Set<number>();
+
+  private server: http.Server;
+  private proxy = coreCreateProxyServer({});
 
   constructor(proxyUrl: string) {
-    super({
-      port: 0,
-
-      prepareRequestFunction: ({ connectionId, hostname, request }) => {
-        const url = request?.url ?? "";
-        const isEventsPath = url.endsWith("/v1/events");
-
-        const internalBypassTests = new Set([
-          "0.0.0.0",
-          process.env.HOST,
-        ]);
-
-        if (env.PROXY_INTERNAL_BYPASS) {
-          for (const host of env.PROXY_INTERNAL_BYPASS.split(",")) {
-            internalBypassTests.add(host.trim());
-          }
-        }
-
-        const isInternalBypass = internalBypassTests.has(hostname);
-
-        if (isEventsPath) {
-          console.error("Bypassing /events request:", url, hostname, isInternalBypass);
-          console.error(`\x1b[1m\x1b[91m{ url: "${url}", hostname: "${hostname}", isInternalBypass: "${isInternalBypass}" }\x1b[0m`);
-        }
-
-        if (isInternalBypass) {
-          
-          this.hostConnections.add(connectionId);
-          return {
-            requestAuthentication: false,
-            upstreamProxyUrl: null, // This will ensure that events sent back to the api are not proxied
-          };
-        }
-        return {
-          requestAuthentication: false,
-          upstreamProxyUrl: proxyUrl,
-        };
-      },
-    });
-
-    this.on("connectionClosed", ({ connectionId, stats }) => {
-      if (stats && !this.hostConnections.has(connectionId)) {
-        this.txBytes += stats.trgTxBytes;
-        this.rxBytes += stats.trgRxBytes;
-      }
-      this.hostConnections.delete(connectionId);
-    });
-
-    this.url = `http://127.0.0.1:${this.port}`;
     this.upstreamProxyUrl = proxyUrl;
+
+    this.server = http.createServer((req, res) => {
+      const hostname = req.headers.host?.split(":")[0];
+      const url = req.url ?? "";
+      const isEventsPath = url.endsWith("/v1/events");
+
+      const internalBypassTests = new Set([
+        "0.0.0.0",
+        process.env.HOST,
+      ]);
+
+      if (env.PROXY_INTERNAL_BYPASS) {
+        for (const host of env.PROXY_INTERNAL_BYPASS.split(",")) {
+          internalBypassTests.add(host.trim());
+        }
+      }
+
+      const isInternalBypass = internalBypassTests.has(hostname);
+
+      if (isEventsPath) {
+        console.error("Bypassing /events request:", url, hostname, isInternalBypass);
+        console.error(`\x1b[1m\x1b[91m{ url: "${url}", hostname: "${hostname}", isInternalBypass: "${isInternalBypass}" }\x1b[0m`);
+      }
+
+      const target = isInternalBypass ? `http://${hostname}` : proxyUrl;
+
+      this.proxy.web(req, res, { target }, (err) => {
+        console.error("Proxy error:", err);
+        res.writeHead(502);
+        res.end("Proxy error");
+      });
+
+      req.on("end", () => {
+        const contentLength = parseInt(req.headers["content-length"] || "0", 10);
+        this.txBytes += contentLength;
+      });
+    });
+
+    this.url = ""; // Set after listen()
   }
 
   async listen(): Promise<void> {
-    await super.listen();
-    this.url = `http://127.0.0.1:${this.port}`;
+    return new Promise((resolve) => {
+      this.server.listen(0, "127.0.0.1", () => {
+        const addr = this.server.address();
+        if (typeof addr === "object" && addr?.port) {
+          this.url = `http://127.0.0.1:${addr.port}`;
+        }
+        resolve();
+      });
+    });
+  }
+
+  close(_force?: boolean) {
+    return this.server.close();
   }
 }
 
@@ -73,7 +77,7 @@ const proxyReclaimRegistry = new FinalizationRegistry((heldValue: Function) => h
 export async function createProxyServer(proxyUrl: string): Promise<ProxyServer> {
   const proxy = new ProxyServer(proxyUrl);
   await proxy.listen();
-  proxyReclaimRegistry.register(proxy, proxy.close);
+  proxyReclaimRegistry.register(proxy, () => proxy.close());
   return proxy;
 }
 
@@ -81,13 +85,9 @@ export async function getProxyServer(
   proxyUrl: string | null | undefined,
   session: SessionService,
 ): Promise<ProxyServer | null> {
-  if (proxyUrl === null) {
-    return null;
-  }
-
+  if (proxyUrl === null) return null;
   if (proxyUrl === undefined || proxyUrl === session.activeSession.proxyServer?.upstreamProxyUrl) {
     return session.activeSession.proxyServer ?? null;
   }
-
   return createProxyServer(proxyUrl);
 }

--- a/api/src/utils/proxy.ts
+++ b/api/src/utils/proxy.ts
@@ -1,7 +1,55 @@
 import { env } from "../env.js";
 import { SessionService } from "../services/session.service.js";
-import { Server } from "proxy-chain";
+import { PrepareRequestFunctionOpts, PrepareRequestFunctionResult, Server } from "proxy-chain";
 import { PassthroughServer } from "./passthough-proxy.js";
+import http, { IncomingHttpHeaders } from "node:http";
+
+const hopByHop = new Set([
+  "connection",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "keep-alive",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const makePassthrough = function ({ request, hostname, port }: PrepareRequestFunctionOpts): NonNullable<PrepareRequestFunctionResult['customResponseFunction']> {
+  return async () => {
+    const proxyRes = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        const forward = http.request(
+          {
+            hostname,
+            port,
+            method: request.method,
+            path: request.url,
+            headers: request.headers,
+          },
+          resolve,
+        );
+        forward.on("error", reject);
+        request.pipe(forward);
+      });
+    
+    const chunks: Buffer[] = [];
+    for await (const chunk of proxyRes) chunks.push(chunk);
+    const body = Buffer.concat(chunks);
+
+    const headers: IncomingHttpHeaders = {};
+    for (const [k, v] of Object.entries(proxyRes.headers)) {
+      if (!hopByHop.has(k.toLowerCase()) && v !== undefined) {
+        headers[k] = Array.isArray(v) ? v.join(",") : v;
+      }
+    }
+    
+    return {
+      statusCode: proxyRes.statusCode ?? 500,
+      headers: proxyRes.headers as Record<string, string>,
+      body,
+    };
+  };
+}
 
 export class ProxyServer extends Server {
   public url: string;
@@ -14,7 +62,8 @@ export class ProxyServer extends Server {
     super({
       port: 0,
 
-      prepareRequestFunction: ({ connectionId, hostname, request }) => {
+      prepareRequestFunction: (options) => {
+        const { connectionId, hostname, request } = options;
         const url = request?.url ?? "";
         const isEventsPath = url.endsWith("/v1/events");
 
@@ -46,6 +95,7 @@ export class ProxyServer extends Server {
 
           return {
             customConnectServer: PassthroughServer,
+            customResponseFunction: makePassthrough(options),
           };
         }
         return {

--- a/api/src/utils/proxy.ts
+++ b/api/src/utils/proxy.ts
@@ -17,11 +17,6 @@ export class ProxyServer extends Server {
         const url = request?.url ?? "";
         const isEventsPath = url.endsWith("/v1/events");
 
-        if (isEventsPath) {
-          console.error("Bypassing /events request:", url, hostname);
-          console.error(`\x1b[1m\x1b[91m{ url: "${url}", hostname: "${hostname}" }\x1b[0m`);
-        }
-
         const internalBypassTests = new Set([
           "0.0.0.0",
           process.env.HOST,
@@ -35,7 +30,13 @@ export class ProxyServer extends Server {
 
         const isInternalBypass = internalBypassTests.has(hostname);
 
+        if (isEventsPath) {
+          console.error("Bypassing /events request:", url, hostname, isInternalBypass);
+          console.error(`\x1b[1m\x1b[91m{ url: "${url}", hostname: "${hostname}", isInternalBypass: "${isInternalBypass}" }\x1b[0m`);
+        }
+
         if (isInternalBypass) {
+          
           this.hostConnections.add(connectionId);
           return {
             requestAuthentication: false,

--- a/api/src/utils/proxy.ts
+++ b/api/src/utils/proxy.ts
@@ -19,6 +19,11 @@ type Result<T> = [err: Error, result: null] | [err: null, result: T];
 
 const makePassthrough = function ({ request, hostname, port }: PrepareRequestFunctionOpts): NonNullable<PrepareRequestFunctionResult['customResponseFunction']> {
   return async () => {
+    const headerString = `{ ${Object.entries(request.headers)
+      .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+      .join(", ")} }`;
+    console.error(`Incoming clientReq.headers: ${headerString}`);
+
     const [err, proxyRes]: Result<http.IncomingMessage> = await new Promise((resolve) => {
       const forward = http.request(
         {

--- a/api/src/utils/proxy.ts
+++ b/api/src/utils/proxy.ts
@@ -1,67 +1,7 @@
 import { env } from "../env.js";
 import { SessionService } from "../services/session.service.js";
-import { PrepareRequestFunctionOpts, PrepareRequestFunctionResult, Server } from "proxy-chain";
-import { PassthroughServer } from "./passthough-proxy.js";
-import http, { IncomingHttpHeaders } from "node:http";
-
-const hopByHop = new Set([
-  "connection",
-  "proxy-authenticate",
-  "proxy-authorization",
-  "keep-alive",
-  "te",
-  "trailers",
-  "transfer-encoding",
-  "upgrade",
-]);
-
-type Result<T> = [err: Error, result: null] | [err: null, result: T];
-
-/**
- * There's an issue with proxy-chain's handling of chunked requests when doing a direct passthrough.
- * This workaround forwards the requests manually and returns the response
- */
-const makePassthrough = function ({ request, hostname, port }: PrepareRequestFunctionOpts): NonNullable<PrepareRequestFunctionResult['customResponseFunction']> {
-  return async () => {
-    const [err, proxyRes]: Result<http.IncomingMessage> = await new Promise((resolve) => {
-      const forward = http.request(
-        {
-          hostname,
-          port,
-          method: request.method,
-          path: request.url,
-          headers: request.headers,
-        },
-        (res) => resolve([null, res]),
-      );
-
-      forward.on("error", (err) => resolve([err, null]));
-      request.pipe(forward);
-    });
-
-    if (err) {
-      console.error(`Request failed "${err.name}": ${err.message}`)
-      throw err;
-    }
-    
-    const chunks: Buffer[] = [];
-    for await (const chunk of proxyRes) chunks.push(chunk);
-    const body = Buffer.concat(chunks);
-
-    const headers: IncomingHttpHeaders = {};
-    for (const [k, v] of Object.entries(proxyRes.headers)) {
-      if (!hopByHop.has(k.toLowerCase()) && v !== undefined) {
-        headers[k] = Array.isArray(v) ? v.join(",") : v;
-      }
-    }
-    
-    return {
-      statusCode: proxyRes.statusCode ?? 500,
-      headers: proxyRes.headers as Record<string, string>,
-      body,
-    };
-  };
-}
+import { Server } from "proxy-chain";
+import { makePassthrough, PassthroughServer } from "./passthough-proxy.js";
 
 export class ProxyServer extends Server {
   public url: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "fingerprint-generator": "2.1.62",
         "fingerprint-injector": "2.1.62",
         "http-proxy": "^1.18.1",
+        "http-proxy-3": "^1.20.5",
         "https-proxy-agent": "^7.0.6",
         "iconv-lite": "^0.6.3",
         "jsdom": "^26.0.0",
@@ -491,6 +492,7 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -8229,6 +8231,19 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-3": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-3/-/http-proxy-3-1.20.5.tgz",
+      "integrity": "sha512-7IfF7DIyZZmOVf7r8pl/H2BypTFvfgcCe36IwLlQV/725CoT2RXSqR6tXncsERDQCNlL5DWykfOIP1S8H+J4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "follow-redirects": "^1.15.9"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/http-proxy-agent": {


### PR DESCRIPTION
There's an issue with how proxy-chain's direct requests handle `transfer-encoding=chunked` requests where the headers/body become malformed. 

This bypasses these issues by providing a simple reverse proxy for `CONNECT` commands and performs the request inline for each following request after the connection has been established. 