### PR TITLE
Update API links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,14 +155,14 @@ There are two main ways to interact with the Steel browser API:
 
 In these examples, we assume your custom Steel API endpoint is `http://localhost:3000`.
 
-The full REST API documentation can be found on your Steel instance at `/documentation` (e.g., `http://localhost:3000/documentation`).
+The full REST OpenAPI documentation can be found [on our site](https://docs.steel.dev/api-reference) and on your local Steel instance at `http://localhost:3000/documentation`.
 
 #### Using the SDKs
 If you prefer to use the our Python and Node SDKs, you can install the `steel-sdk` package for Node or Python.
 
 These SDKs are built on top of the REST API and provide a more convenient way to interact with the Steel browser API. They are fully typed, and are compatible with both Steel Cloud and self-hosted Steel instances (changeable using the `baseURL` option on Node and `base_url` on Python). 
 
-For more details on installing and using the SDKs, please see the [Node SDK Reference](https://docs.steel.dev/overview/reference/node-sdk-reference) and the [Python SDK Reference](https://docs.steel.dev/overview/reference/python-sdk-reference).
+For more details on installing and using the SDKs, please see the [Node SDK Reference](https://github.com/steel-dev/steel-node/blob/main/api.md) and the [Python SDK Reference](https://github.com/steel-dev/steel-python/blob/main/api.md).
 
 
 ### Sessions


### PR DESCRIPTION
1. The links for the SDK reference docs are outdated and lead to 404s. Replaced with direct links to the relevant `api.md` files.

2. AFAICT the OpenAPI docs aren't linked anywhere in this document, so I included those in the Usage section.

3. You use "/documentation, e.g. localhost:3000/documentation"  right after saying that all examples use localhost, which seems unnecessary -- removed the first clause.

Great work, new user here -- excited to try it out! Obviously just trying to help out, merge/delete as you see fit :)