### PR TITLE
fix: Polyfill `__name` to prevent esbuild errors in Puppeteer context

### DIFF
--- a/api/src/modules/actions/actions.controller.ts
+++ b/api/src/modules/actions/actions.controller.ts
@@ -65,6 +65,13 @@ export const handleScrape = async (
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
 
+    // Polyfill the __name function injected by esbuild
+    // https://github.com/evanw/esbuild/issues/2605#issuecomment-2146054255
+    // https://github.com/cloudflare/workers-sdk/issues/7107
+    await page.evaluate(() => {
+      (window as any).__name = (func: Function) => func;
+    });
+
     const [{ html, metadata, links }, base64Screenshot, pdfBuffer] = await Promise.all([
       page.evaluate(() => {
         const getMetaContent = (selector: string) => {


### PR DESCRIPTION
This PR resolves a `ReferenceError: __name is not defined` that occurs when running Puppeteer operations in an environment that uses `esbuild` for transpilation, such as `tsx` or Vitest.

#### The Problem

When using `tsx`, `esbuild` transpiles named function expressions to use a `__name` helper function to preserve the function's `.name` property. For example:

```javascript
// Original code
function myFunc() {}

// Transpiled by esbuild
var myFunc = __name(function() {}, "myFunc");
```

When Puppeteer's `page.evaluate()` executes this transpiled code in the browser, the `__name` helper function does not exist in the `window` scope, causing a fatal `ReferenceError`. This affects not only our own evaluation strings but also Puppeteer's internal helper functions that get serialized and executed in the browser.

#### The Solution

This change introduces a simple and robust fix by injecting a polyfill for `__name` directly onto the page's `window` object.

```typescript
await page.evaluate(() => {
  (window as any).__name = (func: Function) => func;
});
```