### PR TITLE
feat: add onBrowserReady hook to CDP plugin manager

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -639,6 +639,9 @@ export class CDPService extends EventEmitter {
               BrowserProcessState.PAGE_REFRESH,
             );
           }
+
+          this.pluginManager.onBrowserReady(this.launchConfig);
+
           return this.browserInstance!;
         } else if (this.browserInstance) {
           this.logger.info(
@@ -931,6 +934,8 @@ export class CDPService extends EventEmitter {
             `[CDPService] ${setupError.message} - browser may not function correctly`,
           );
         }
+
+        this.pluginManager.onBrowserReady(this.launchConfig);
 
         return this.browserInstance;
       })();

--- a/api/src/services/cdp/plugins/core/base-plugin.ts
+++ b/api/src/services/cdp/plugins/core/base-plugin.ts
@@ -24,6 +24,7 @@ export abstract class BasePlugin {
 
   // Lifecycle methods
   public async onBrowserLaunch(browser: Browser): Promise<void> {}
+  public onBrowserReady(context: BrowserLauncherOptions): void {}
   public async onPageCreated(page: Page): Promise<void> {}
   public async onPageNavigate(page: Page): Promise<void> {}
   public async onPageUnload(page: Page): Promise<void> {}
@@ -32,3 +33,5 @@ export abstract class BasePlugin {
   public async onShutdown(): Promise<void> {}
   public async onSessionEnd(sessionConfig: BrowserLauncherOptions): Promise<void> {}
 }
+
+export type { BrowserLauncherOptions };

--- a/api/src/services/cdp/plugins/core/plugin-manager.ts
+++ b/api/src/services/cdp/plugins/core/plugin-manager.ts
@@ -62,6 +62,16 @@ export class PluginManager {
     await Promise.all(promises);
   }
 
+  public onBrowserReady(context: BrowserLauncherOptions): void {
+    for (const plugin of this.plugins.values()) {
+      try {
+        plugin.onBrowserReady(context);
+      } catch (error) {
+        this.logger.error(`Error in plugin ${plugin.name}.onBrowserReady: ${error}`);
+      }
+    }
+  }
+
   /**
    * Notify all plugins about a page creation
    */


### PR DESCRIPTION
Add the `onBrowserReady` hook to the CDP plugin manager which gets called once the browser is ready and is about to be returned.