### PR TITLE
chore: add a few more static chrome args for headful sessions

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -769,7 +769,7 @@ export class CDPService extends EventEmitter {
           "--remote-allow-origins=*",
           "--disable-dev-shm-usage",
           "--disable-gpu",
-          "--disable-features=PermissionPromptSurvey,IsolateOrigins,site-per-process,TouchpadAndWheelScrollLatching,TrackingProtection3pcd",
+          "--disable-features=LinuxNonClientFrame,PermissionPromptSurvey,IsolateOrigins,site-per-process,TouchpadAndWheelScrollLatching,TrackingProtection3pcd",
           "--enable-features=Clipboard",
           "--no-default-browser-check",
           "--disable-sync",
@@ -800,6 +800,8 @@ export class CDPService extends EventEmitter {
           "--in-process-gpu",
           "--enable-crashpad",
           "--crash-dumps-dir=/tmp/chrome-dumps",
+          "--noerrdialogs",
+          "--force-device-scale-factor=1",
         ];
 
         const headlessArgs = [


### PR DESCRIPTION
- Try and disable chrome window buttons (Close, minimize, maximize)
- Disable crash error dialogs
- Force DPR to be 1, even if user agent reports higher numbers