### PR TITLE
fix: files cleanup is more granular + home dir

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -848,6 +848,7 @@ export class CDPService extends EventEmitter {
           ignoreDefaultArgs: ["--enable-automation"],
           timeout: 0,
           env: {
+            HOME: os.userInfo().homedir,
             TZ: timezone,
             ...(isHeadless ? {} : { DISPLAY: env.DISPLAY }),
           },

--- a/api/src/services/file.service.ts
+++ b/api/src/services/file.service.ts
@@ -306,18 +306,24 @@ export class FileService {
     }
 
     try {
-      await fs.promises.rm(this.baseFilesPath, { recursive: true, force: true });
-      console.log(`[FileService cleanupFiles] Deleted entire directory: ${this.baseFilesPath}`);
+      const files = await fs.promises.readdir(this.baseFilesPath);
+      for (const file of files) {
+        await fs.promises.rm(path.join(this.baseFilesPath, file), {
+          recursive: true,
+          force: true,
+        });
+      }
+      console.log(
+        `[FileService cleanupFiles] Cleared contents of directory: ${this.baseFilesPath}`,
+      );
     } catch (err: any) {
       if (err.code !== "ENOENT") {
         console.error(
-          `[FileService cleanupFiles] Error deleting directory ${this.baseFilesPath}:`,
+          `[FileService cleanupFiles] Error cleaning directory ${this.baseFilesPath}:`,
           err,
         );
       }
     }
-
-    await fs.promises.mkdir(this.baseFilesPath, { recursive: true });
     console.log(`[FileService cleanupFiles] Files cleaned. Creating empty archive.`);
     this.debouncedCreateArchive();
   }


### PR DESCRIPTION
This pull request introduces improvements to environment variable handling for the CDP service and refines the file cleanup logic in the FileService. The main changes focus on ensuring proper user environment configuration and making the file cleanup process safer and more granular.

**Environment variable improvements:**

* In `cdp.service.ts`, the `HOME` environment variable is now explicitly set to the user's home directory using `os.userInfo().homedir` when launching the CDP service. This helps ensure that processes have the correct user context, which can prevent issues related to permissions or incorrect environment setups.

**File cleanup logic refinement:**

* In `file.service.ts`, the `cleanupFiles` method now deletes only the contents of the target directory rather than the entire directory itself. This is done by reading the directory and removing each file or subdirectory individually, which avoids deleting and recreating the directory and helps preserve directory-level permissions or configuration. The log messages have also been updated to reflect this new behavior.