### PR TITLE
fix: circular reference stack overflow in event storage

### DIFF
--- a/api/src/services/cdp/instrumentation/storage/duckdb-storage.ts
+++ b/api/src/services/cdp/instrumentation/storage/duckdb-storage.ts
@@ -4,6 +4,7 @@ import fs from "fs/promises";
 import { LogStorage, LogQuery, LogQueryResult } from "./log-storage.interface.js";
 import { BrowserEventUnion } from "../types.js";
 import { randomUUID } from "crypto";
+import { safeStringify } from "./safe-json.js";
 
 export type ParquetCompression = "zstd" | "snappy" | "gzip" | "none";
 
@@ -182,8 +183,8 @@ export class DuckDBStorage implements LogStorage {
     const eventType = event.type;
     const targetType = event.targetType || null;
     const pageId = event.pageId || null;
-    const data = JSON.stringify(event);
-    const contextJson = JSON.stringify(context);
+    const data = safeStringify(event);
+    const contextJson = safeStringify(context);
 
     await stmt.run(id, timestamp, eventType, targetType, pageId, data, contextJson);
     await stmt.finalize();
@@ -229,8 +230,8 @@ export class DuckDBStorage implements LogStorage {
       const eventType = event.type;
       const targetType = event.targetType || null;
       const pageId = event.pageId || null;
-      const data = JSON.stringify(event);
-      const contextJson = JSON.stringify(context);
+      const data = safeStringify(event);
+      const contextJson = safeStringify(context);
 
       params.push(id, timestamp, eventType, targetType, pageId, data, contextJson);
     }

--- a/api/src/services/cdp/instrumentation/storage/safe-json.ts
+++ b/api/src/services/cdp/instrumentation/storage/safe-json.ts
@@ -1,0 +1,15 @@
+export function safeStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  return JSON.stringify(value, function (_key, currentValue) {
+    if (typeof currentValue === "object" && currentValue !== null) {
+      if (seen.has(currentValue)) {
+        return "[Circular]";
+      }
+
+      seen.add(currentValue);
+    }
+
+    return currentValue;
+  });
+}

--- a/api/src/services/cdp/instrumentation/utils.ts
+++ b/api/src/services/cdp/instrumentation/utils.ts
@@ -1,4 +1,5 @@
 import type { Target, Protocol } from "puppeteer-core";
+import { safeStringify } from "./storage/safe-json.js";
 
 export function extractTargetId(target: Target): string {
   return (target as any)._targetId as string;
@@ -6,7 +7,7 @@ export function extractTargetId(target: Target): string {
 
 export function serializeRemoteObject(obj: Protocol.Runtime.RemoteObject): string {
   if (obj.value !== undefined) {
-    return typeof obj.value === "object" ? JSON.stringify(obj.value, null, 2) : String(obj.value);
+    return typeof obj.value === "object" ? safeStringify(obj.value) : String(obj.value);
   }
   return obj.description ?? "<unknown>";
 }


### PR DESCRIPTION
## Description

Adds safeStringify utility to handle circular references in browser events. Updates DuckDB storage and serializeRemoteObject to prevent stack overflow during JSON serialization.