### PR TITLE
docs: fix broken documentation guide URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ For more details on installing and using the SDKs, please see the [Node SDK Refe
 The `/sessions` endpoint lets you relaunch the browser with custom options or extensions (e.g. with a custom proxy) and also reset the browser state. Perfect for complex, stateful workflows that need fine-grained control.
 
 Once you have a session, you can use the session ID or the root URL to interact with the browser. To do this, you will need to use Puppeteer or Playwright. You can find some examples of how to use Puppeteer and Playwright with Steel in the docs below:
-* [Puppeteer Integration](https://docs.steel.dev/overview/guides/connect-with-puppeteer)
-* [Playwright with Node](https://docs.steel.dev/overview/guides/connect-with-playwright-node)
-* [Playwright with Python](https://docs.steel.dev/overview/guides/connect-with-playwright-python)
+* [Puppeteer Integration](https://docs.steel.dev/overview/guides/puppeteer)
+* [Playwright with Node](https://docs.steel.dev/overview/guides/playwright-node)
+* [Playwright with Python](https://docs.steel.dev/overview/guides/playwright-python)
 
 <details open>
 <summary><b>Creating a Session using the Node SDK</b></summary>
@@ -280,7 +280,7 @@ curl -X POST http://localhost:3000/v1/sessions \
 </details>
 <br>
 
-The Selenium API is fully compatible with Selenium's WebDriver protocol, so you can use any existing Selenium clients to connect to the Steel browser. **For more details on using Selenium with Steel, refer to the [Selenium Docs](https://docs.steel.dev/overview/guides/connect-with-selenium).**
+The Selenium API is fully compatible with Selenium's WebDriver protocol, so you can use any existing Selenium clients to connect to the Steel browser. **For more details on using Selenium with Steel, refer to the [Selenium Docs](https://docs.steel.dev/overview/guides/selenium).**
 
 ### Quick Actions API
 The `/scrape`, `/screenshot`, and `/pdf` endpoints let you quickly extract clean, well-formatted data from any webpage using the running Steel server. Ideal for simple, read-only, on-demand jobs:


### PR DESCRIPTION
## Description

  Fix broken documentation guide URLs in README that point to outdated paths.

  ## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work
   as expected)
  - [x] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test addition/update

  ## Related Issues

  N/A

  ## Changes Made

  - [x] Updated guide URLs from old `connect-with-*` format to current paths:
    - `connect-with-puppeteer` -> `puppeteer`
    - `connect-with-playwright-node` -> `playwright-node`
    - `connect-with-playwright-python` -> `playwright-python`
    - `connect-with-selenium` -> `selenium`

  ## Testing

  - [x] I have tested this locally
  - [ ] I have added/updated unit tests
  - [ ] I have added/updated integration tests
  - [ ] I have tested with Docker
  - [ ] All existing tests pass

  ## Documentation

  - [x] I have updated the README if needed

  ## Code Quality

  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code