### PR TITLE
Add concurrent browser session support - PoC

### DIFF
--- a/README_CONCURRENT.md
+++ b/README_CONCURRENT.md
@@ -1,0 +1,300 @@
+# Steel Browser — Concurrent Multi-Session Fork
+
+This is a modified fork of [steel-browser](https://github.com/steel-dev/steel-browser) (MIT license) that adds **concurrent multi-session support** within a single Docker container.
+
+The upstream open-source version supports only a single active browser session at a time. This fork introduces a `BrowserPool` that manages multiple independent Chromium instances, each on its own CDP port, allowing N sessions to run simultaneously.
+
+---
+
+## Quick Start (Pre-Built Image)
+
+If the image has already been built (tagged `steel-browser-api:latest`), start it with docker compose:
+
+```bash
+# From the steel-browser/ directory
+MAX_SESSIONS=5 CDP_PORT_BASE=9222 DOMAIN=localhost:3000 \
+  docker compose -f docker-compose.dev.yml up -d api
+```
+
+Or with the production compose file (uses the published GHCR image — note: the published image does **not** include these concurrency changes):
+
+```bash
+docker compose up -d api
+```
+
+### PowerShell (Windows)
+
+```powershell
+$env:MAX_SESSIONS = "5"
+$env:CDP_PORT_BASE = "9222"
+$env:DOMAIN = "localhost:3000"
+docker compose -f docker-compose.dev.yml up -d api
+```
+
+The API will be available at `http://localhost:3000`.
+
+---
+
+## Building from Source
+
+```bash
+# From the steel-browser/ directory
+docker compose -f docker-compose.dev.yml up -d --build api
+```
+
+This builds the image from `./api/Dockerfile` and starts the container. The build takes 5–15 minutes depending on network speed (it downloads Chromium inside the image).
+
+### Build with custom settings
+
+```bash
+MAX_SESSIONS=10 CDP_PORT_BASE=9222 DOMAIN=localhost:3000 \
+  docker compose -f docker-compose.dev.yml up -d --build api
+```
+
+---
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `MAX_SESSIONS` | `5` | Maximum number of concurrent browser sessions |
+| `CDP_PORT_BASE` | `9222` | Base port for Chrome DevTools Protocol. Each session gets its own port: `CDP_PORT_BASE`, `CDP_PORT_BASE+1`, ..., `CDP_PORT_BASE+N-1` |
+| `DOMAIN` | `localhost:3000` | Domain used to construct session URLs (debug, websocket, etc.) |
+| `CDP_DOMAIN` | `localhost:9223` | Domain for external CDP access |
+
+Sessions are allocated on demand — no memory or processes are pre-allocated. Setting `MAX_SESSIONS` to a high number is safe; each Chromium instance only launches when a session is created and shuts down when it is released. A single Chromium instance uses roughly **100–300 MB RAM** depending on page complexity.
+
+### Docker resource requirements
+
+- **`shm_size: "2gb"`** is set in both compose files. Chrome requires shared memory for rendering; without it, tabs will crash. Scale this up if running many sessions with heavy pages.
+- **RAM**: Budget ~300 MB per concurrent session plus ~200 MB for the Node.js API server. For `MAX_SESSIONS=5`, allocate at least 2 GB to the container.
+
+---
+
+## API Usage
+
+### Create a session
+
+```bash
+curl -X POST http://localhost:3000/v1/sessions \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Response:
+
+```json
+{
+  "id": "7ffb628a-bbd3-4363-950b-9972763ad81a",
+  "status": "live",
+  "websocketUrl": "ws://localhost:3000/v1/sessions/7ffb628a-.../cdp",
+  "debugUrl": "http://localhost:3000/v1/sessions/7ffb628a-.../debug",
+  "dimensions": { "width": 1920, "height": 1080 },
+  "createdAt": "2026-03-15T00:15:25.531Z"
+}
+```
+
+### List active sessions
+
+```bash
+curl http://localhost:3000/v1/sessions
+```
+
+### Get session details
+
+```bash
+curl http://localhost:3000/v1/sessions/{sessionId}
+```
+
+### Get live details (pages, browser state)
+
+```bash
+curl http://localhost:3000/v1/sessions/{sessionId}/live-details
+```
+
+### Release a session
+
+```bash
+curl -X POST http://localhost:3000/v1/sessions/{sessionId}/release
+```
+
+### Health check
+
+```bash
+curl http://localhost:3000/v1/health
+```
+
+Response includes pool status:
+
+```json
+{
+  "status": "ok",
+  "activeSessions": 2,
+  "maxSessions": 5
+}
+```
+
+### Pool exhaustion
+
+When all slots are occupied, creating a new session returns **HTTP 503**:
+
+```json
+{
+  "statusCode": 503,
+  "error": "Service Unavailable",
+  "message": "Session pool is full (max 5 sessions). Release an existing session and retry."
+}
+```
+
+---
+
+## Live Preview
+
+Each session has a live screencast accessible in a browser:
+
+```
+http://localhost:3000/v1/sessions/{sessionId}/debug
+```
+
+Query parameters:
+- `interactive=true|false` — enable/disable mouse/keyboard input forwarding
+- `showControls=true|false` — show/hide the control bar
+- `pageId={id}` or `pageIndex={n}` — target a specific tab
+
+### Side-by-side preview
+
+To view multiple sessions at once, embed iframes pointing to each session's debug URL. The test suite includes a `live-viewer.html` generator that does exactly this — see the Testing section below.
+
+---
+
+## Connecting via Puppeteer / Playwright
+
+Each session exposes a session-specific WebSocket endpoint for CDP connections:
+
+```javascript
+import puppeteer from "puppeteer-core";
+
+// Create a session first via the REST API, then connect:
+const browser = await puppeteer.connect({
+  browserWSEndpoint: "ws://localhost:3000/v1/sessions/{sessionId}/cdp",
+});
+
+const page = (await browser.pages())[0];
+await page.goto("https://example.com");
+console.log(await page.title());
+
+browser.disconnect(); // disconnect (don't close — the session keeps running)
+```
+
+For Playwright:
+
+```javascript
+import { chromium } from "playwright";
+
+const browser = await chromium.connectOverCDP(
+  "ws://localhost:3000/v1/sessions/{sessionId}/cdp"
+);
+```
+
+---
+
+## Architecture
+
+### What changed from upstream
+
+The upstream steel-browser uses a **singleton** `CDPService` — one Chrome instance, one session at a time. This fork replaces that with:
+
+1. **`BrowserPool`** (`api/src/services/browser-pool.service.ts`) — manages an array of `PoolSlot` objects, each containing a `CDPService` instance with a unique `--remote-debugging-port`. Slots are acquired/released by session ID.
+
+2. **`SessionService`** — refactored from tracking a single `activeSession` to a `Map<string, Session>`. Each `Session` holds a reference to its own `CDPService` from the pool.
+
+3. **Session-aware URL generation** — `getSessionUrl(sessionId, path, protocol)` constructs unique `websocketUrl` and `debugUrl` per session (e.g., `/v1/sessions/{id}/cdp`, `/v1/sessions/{id}/debug`).
+
+4. **WebSocket routing** — the `WebSocketRegistry` matches incoming connections to the correct session via URL pattern matching (`/v1/sessions/:id/cast`, `/v1/sessions/:id/cdp`), then proxies to the correct Chrome instance.
+
+5. **Casting handler** — connects Puppeteer to the session-specific Chrome via `cdpService.getWsEndpoint()` rather than a hardcoded port.
+
+### Changed files
+
+| File | Change |
+|---|---|
+| `api/src/services/browser-pool.service.ts` | **New.** Pool of CDPService instances |
+| `api/src/services/session.service.ts` | Singleton → Map-based multi-session |
+| `api/src/services/cdp/cdp.service.ts` | Parameterized `--remote-debugging-port`; added `getWsEndpoint()` |
+| `api/src/env.ts` | Added `MAX_SESSIONS`, `CDP_PORT_BASE` |
+| `api/src/utils/url.ts` | Added `getSessionUrl()` |
+| `api/src/plugins/browser.ts` | Instantiates `BrowserPool` instead of singleton `CDPService` |
+| `api/src/plugins/browser-session.ts` | Passes `browserPool` to `SessionService` |
+| `api/src/modules/sessions/sessions.controller.ts` | Session-ID-aware handlers; 503 on pool full |
+| `api/src/modules/sessions/sessions.routes.ts` | Added `/sessions/:sessionId/debug`; health reports pool stats |
+| `api/src/services/websocket-registry.service.ts` | Added `matchHandlerWithSession()` for URL-based session routing |
+| `api/src/plugins/browser-socket/browser-socket.ts` | Session-aware WebSocket upgrade routing |
+| `api/src/plugins/browser-socket/casting.handler.ts` | Connects to session-specific Chrome via `getWsEndpoint()` |
+| `api/src/types/fastify.d.ts` | Added `browserPool` to FastifyInstance |
+| `api/src/types/websocket.ts` | Added `sessionId` to WebSocketHandlerContext |
+| `api/src/steel-browser-plugin.ts` | Registered `browserPool` decorator |
+| `docker-compose.yml` | Added `shm_size`, `MAX_SESSIONS`, `CDP_PORT_BASE` |
+| `docker-compose.dev.yml` | Same as above (build variant) |
+
+### Backward compatibility
+
+- The Fastify instance still exposes `server.cdpService` pointing to the first pool slot's CDPService, so any legacy code referencing it continues to work.
+- Routes that don't specify a session ID fall back to using the first active session.
+
+---
+
+## Testing
+
+A comprehensive test suite lives in `../test-steel-browser-concurrency/`.
+
+### Concurrency test (`test-concurrency.ts`)
+
+An 8-step automated test that validates:
+
+1. **Health check** — API reports `activeSessions=0`, `maxSessions=N`
+2. **Concurrent session creation** — creates N sessions, verifies unique IDs and session-specific URLs
+3. **List sessions** — `GET /v1/sessions` returns all N
+4. **Pool exhaustion** — session N+1 returns HTTP 503
+5. **CDP connections** — Puppeteer connects to each session, navigates to different URLs, verifies isolation
+6. **Live details** — `GET /v1/sessions/:id/live-details` returns pages and browserState
+7. **Release & reuse** — releases one session, creates a new one in the freed slot
+8. **Teardown** — releases all, verifies list is empty
+
+Run it (with the container already running):
+
+```bash
+cd test-steel-browser-concurrency
+npm install
+npx tsx test-concurrency.ts
+```
+
+### Mouse movement demo (`test-mouse-movement.ts`)
+
+Creates 3 sessions, navigates each to a different page, injects a colored cursor indicator, and moves the mouse to random coordinates every 3 seconds for 60 seconds. Generates `live-viewer.html` — a side-by-side live preview page — and opens it in the default browser.
+
+```bash
+npx tsx test-mouse-movement.ts
+```
+
+### Full orchestrated run (`run-tests.ps1`)
+
+PowerShell script that handles the full lifecycle: tear down existing containers, build and start the image, install dependencies, run the test suite, and tear down.
+
+```powershell
+cd test-steel-browser-concurrency
+.\run-tests.ps1
+```
+
+---
+
+## Stopping
+
+```bash
+docker compose -f docker-compose.dev.yml down
+```
+
+To also remove volumes:
+
+```bash
+docker compose -f docker-compose.dev.yml down -v
+```

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -81,6 +81,8 @@ const envSchema = z.object({
     .optional()
     .transform((val) => val === "true" || val === "1")
     .default("false"),
+  MAX_SESSIONS: z.coerce.number().default(5),
+  CDP_PORT_BASE: z.coerce.number().default(9222),
 });
 
 export const env = envSchema.parse(process.env);

--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -3,7 +3,8 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { getErrors } from "../../utils/errors.js";
 import { CreateSessionRequest, SessionDetails, SessionStreamRequest } from "./sessions.schema.js";
 import { CookieData } from "../../services/context/types.js";
-import { getUrl, getBaseUrl } from "../../utils/url.js";
+import { getUrl, getBaseUrl, getSessionUrl } from "../../utils/url.js";
+import { env } from "../../env.js";
 
 export const handleLaunchBrowserSession = async (
   server: FastifyInstance,
@@ -58,20 +59,44 @@ export const handleLaunchBrowserSession = async (
       headless,
     });
   } catch (e: unknown) {
-    server.log.error({ err: e }, "Failed lauching browser session");
+    server.log.error({ err: e }, "Failed launching browser session");
     const error = getErrors(e);
+
+    if (typeof error === "string" && error.includes("Session pool is full")) {
+      return reply.status(503).send({
+        statusCode: 503,
+        error: "Service Unavailable",
+        message: error,
+      });
+    }
+
     return reply.code(500).send({ success: false, message: error });
   }
 };
 
 export const handleExitBrowserSession = async (
   server: FastifyInstance,
-  request: FastifyRequest,
+  request: FastifyRequest<{ Params: { sessionId?: string } }>,
   reply: FastifyReply,
 ) => {
   try {
-    const sessionDetails = await server.sessionService.endSession();
+    const sessionId = request.params.sessionId;
 
+    if (!sessionId) {
+      const sessions = server.sessionService.listSessions();
+      if (sessions.length === 0) {
+        return reply.code(404).send({ success: false, message: "No active sessions to release" });
+      }
+      const sessionDetails = await server.sessionService.endSession(sessions[0].id);
+      return reply.send({ success: true, ...sessionDetails });
+    }
+
+    const session = server.sessionService.getSession(sessionId);
+    if (!session) {
+      return reply.code(404).send({ success: false, message: `Session ${sessionId} not found` });
+    }
+
+    const sessionDetails = await server.sessionService.endSession(sessionId);
     reply.send({ success: true, ...sessionDetails });
   } catch (e: any) {
     const error = getErrors(e);
@@ -80,11 +105,15 @@ export const handleExitBrowserSession = async (
 };
 
 export const handleGetBrowserContext = async (
-  browserService: CDPService,
-  request: FastifyRequest,
+  server: FastifyInstance,
+  request: FastifyRequest<{ Params: { sessionId: string } }>,
   reply: FastifyReply,
 ) => {
-  const context = await browserService.getBrowserState();
+  const session = server.sessionService.getSession(request.params.sessionId);
+  if (!session) {
+    return reply.code(404).send({ message: `Session ${request.params.sessionId} not found` });
+  }
+  const context = await session.cdpService.getBrowserState();
   return reply.send(context);
 };
 
@@ -94,31 +123,17 @@ export const handleGetSessionDetails = async (
   reply: FastifyReply,
 ) => {
   const sessionId = request.params.sessionId;
-  if (sessionId !== server.sessionService.activeSession.id) {
-    return reply.send({
-      id: sessionId,
-      createdAt: new Date().toISOString(),
-      status: "released",
-      duration: 0,
-      eventCount: 0,
-      timeout: 0,
-      creditsUsed: 0,
-      websocketUrl: getBaseUrl("ws"),
-      debugUrl: getUrl("v1/sessions/debug"),
-      debuggerUrl: getUrl("v1/devtools/inspector.html"),
-      sessionViewerUrl: getBaseUrl(),
-      userAgent: "",
-      isSelenium: false,
-      proxy: "",
-      proxyTxBytes: 0,
-      proxyRxBytes: 0,
-      solveCaptcha: false,
-    } as SessionDetails);
+  const session = server.sessionService.getSession(sessionId);
+
+  if (!session) {
+    return reply.code(404).send({
+      statusCode: 404,
+      error: "Not Found",
+      message: `Session ${sessionId} not found`,
+    });
   }
 
-  const session = server.sessionService.activeSession;
-  const duration = new Date().getTime() - new Date(session.createdAt).getTime();
-  console.log("duration", duration);
+  const duration = Date.now() - new Date(session.createdAt).getTime();
   return reply.send({
     ...session,
     duration,
@@ -130,38 +145,60 @@ export const handleGetSessions = async (
   request: FastifyRequest,
   reply: FastifyReply,
 ) => {
-  const currentSession = {
-    ...server.sessionService.activeSession,
-    duration:
-      new Date().getTime() - new Date(server.sessionService.activeSession.createdAt).getTime(),
-  };
-  const pastSessions = server.sessionService.pastSessions;
-  return reply.send({ sessions: [currentSession, ...pastSessions] });
+  const sessions = server.sessionService.listSessions().map((s) => ({
+    id: s.id,
+    createdAt: s.createdAt,
+    status: s.status,
+    duration: Date.now() - new Date(s.createdAt).getTime(),
+    eventCount: s.eventCount,
+    timeout: s.timeout,
+    creditsUsed: s.creditsUsed,
+    websocketUrl: s.websocketUrl,
+    debugUrl: s.debugUrl,
+    debuggerUrl: s.debuggerUrl,
+    sessionViewerUrl: s.sessionViewerUrl,
+    userAgent: s.userAgent,
+    dimensions: s.dimensions,
+    proxy: s.proxy,
+    proxyTxBytes: s.proxyTxBytes,
+    proxyRxBytes: s.proxyRxBytes,
+    solveCaptcha: s.solveCaptcha,
+    isSelenium: s.isSelenium,
+  }));
+  return reply.send({ sessions });
 };
 
 export const handleGetSessionStream = async (
   server: FastifyInstance,
-  request: SessionStreamRequest,
+  request: SessionStreamRequest & FastifyRequest<{ Params: { sessionId?: string } }>,
   reply: FastifyReply,
 ) => {
   const { showControls, theme, interactive, pageId, pageIndex } = request.query;
+  const sessionId = request.params.sessionId;
 
   const singlePageMode = !!(pageId || pageIndex);
 
-  // Construct WebSocket URL with page parameters if present
-  let wsUrl = getUrl("v1/sessions/cast", "ws");
+  let wsUrl: string;
+  if (sessionId) {
+    wsUrl = getSessionUrl(sessionId, "cast", "ws");
+  } else {
+    wsUrl = getUrl("v1/sessions/cast", "ws");
+  }
+
   if (pageId) {
     wsUrl += `?pageId=${encodeURIComponent(pageId)}`;
   } else if (pageIndex) {
     wsUrl += `?pageIndex=${encodeURIComponent(pageIndex)}`;
   }
 
+  const session = sessionId ? server.sessionService.getSession(sessionId) : null;
+
   return reply.view("live-session-streamer.ejs", {
     wsUrl,
     showControls,
     theme,
     interactive,
-    dimensions: server.sessionService.activeSession.dimensions,
+    dimensions: session?.dimensions || { width: 1920, height: 1080 },
     singlePageMode,
   });
 };
@@ -172,12 +209,22 @@ export const handleGetSessionLiveDetails = async (
   reply: FastifyReply,
 ) => {
   try {
-    const pages = await server.cdpService.getAllPages();
+    const session = server.sessionService.getSession(request.params.id);
+    if (!session) {
+      return reply.code(404).send({
+        statusCode: 404,
+        error: "Not Found",
+        message: `Session ${request.params.id} not found`,
+      });
+    }
+
+    const cdpService = session.cdpService;
+    const pages = await cdpService.getAllPages();
 
     const pagesInfo = await Promise.all(
       pages.map(async (page) => {
         try {
-          const pageId = page.target()._targetId;
+          const pageId = (page.target() as any)._targetId;
 
           const title = await page.title();
 
@@ -205,7 +252,7 @@ export const handleGetSessionLiveDetails = async (
             favicon,
           };
         } catch (error) {
-          console.error("Error collecting page info:", error);
+          server.log.error({ err: error }, "Error collecting page info");
           return null;
         }
       }),
@@ -213,28 +260,23 @@ export const handleGetSessionLiveDetails = async (
 
     const validPagesInfo = pagesInfo.filter((page) => page !== null);
 
-    const browserVersion = await server.cdpService.getBrowserState();
-
     const browserState = {
-      status: server.sessionService.activeSession.status,
-      userAgent: server.sessionService.activeSession.userAgent,
-      browserVersion,
-      initialDimensions: server.sessionService.activeSession.dimensions || {
-        width: 1920,
-        height: 1080,
-      },
+      status: session.status,
+      userAgent: session.userAgent,
+      browserVersion: await cdpService.getBrowserState(),
+      initialDimensions: session.dimensions || { width: 1920, height: 1080 },
       pageCount: validPagesInfo.length,
     };
 
     return reply.send({
       pages: validPagesInfo,
       browserState,
-      websocketUrl: server.sessionService.activeSession.websocketUrl,
-      sessionViewerUrl: server.sessionService.activeSession.sessionViewerUrl,
-      sessionViewerFullscreenUrl: `${server.sessionService.activeSession.sessionViewerUrl}?showControls=false`,
+      websocketUrl: session.websocketUrl,
+      sessionViewerUrl: session.sessionViewerUrl,
+      sessionViewerFullscreenUrl: `${session.sessionViewerUrl}?showControls=false`,
     });
   } catch (error) {
-    console.error("Error getting session state:", error);
+    server.log.error({ err: error }, "Error getting session state");
     return reply.code(500).send({
       message: "Failed to get session state",
       error: getErrors(error),

--- a/api/src/modules/sessions/sessions.routes.ts
+++ b/api/src/modules/sessions/sessions.routes.ts
@@ -26,18 +26,23 @@ async function routes(server: FastifyInstance) {
     {
       schema: {
         operationId: "health",
-        description: "Check if the server and browser are running",
+        description: "Check if the server and browser pool are running",
         tags: ["Health"],
-        summary: "Check if the server and browser are running",
+        summary: "Check if the server and browser pool are running",
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
-      if (!server.cdpService.isRunning()) {
+      if (!server.browserPool) {
         return reply.status(503).send({ status: "service_unavailable" });
       }
-      return reply.send({ status: "ok" });
+      return reply.send({
+        status: "ok",
+        activeSessions: server.browserPool.activeCount,
+        maxSessions: server.browserPool.maxSessions,
+      });
     },
   );
+
   server.post(
     "/sessions",
     {
@@ -103,8 +108,8 @@ async function routes(server: FastifyInstance) {
         },
       },
     },
-    async (request: FastifyRequest, reply: FastifyReply) =>
-      handleGetBrowserContext(server.cdpService, request, reply),
+    async (request: FastifyRequest<{ Params: { sessionId: string } }>, reply: FastifyReply) =>
+      handleGetBrowserContext(server, request, reply),
   );
 
   server.post(
@@ -120,8 +125,10 @@ async function routes(server: FastifyInstance) {
         },
       },
     },
-    async (request: FastifyRequest, reply: FastifyReply) =>
-      handleExitBrowserSession(server, request, reply),
+    async (
+      request: FastifyRequest<{ Params: { sessionId: string } }>,
+      reply: FastifyReply,
+    ) => handleExitBrowserSession(server, request, reply),
   );
 
   server.post(
@@ -138,7 +145,11 @@ async function routes(server: FastifyInstance) {
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) =>
-      handleExitBrowserSession(server, request, reply),
+      handleExitBrowserSession(
+        server,
+        request as FastifyRequest<{ Params: { sessionId?: string } }>,
+        reply,
+      ),
   );
 
   server.get(
@@ -157,7 +168,37 @@ async function routes(server: FastifyInstance) {
       },
     },
     async (request: SessionStreamRequest, reply: FastifyReply) =>
-      handleGetSessionStream(server, request, reply),
+      handleGetSessionStream(
+        server,
+        request as SessionStreamRequest & FastifyRequest<{ Params: { sessionId?: string } }>,
+        reply,
+      ),
+  );
+
+  server.get(
+    "/sessions/:sessionId/debug",
+    {
+      onRequest: [],
+      schema: {
+        operationId: "get_session_debugger_stream_by_id",
+        description: "Returns an HTML page with a live debugger view for a specific session",
+        tags: ["Sessions"],
+        summary: "Get session-specific debugger view",
+        querystring: $ref("SessionStreamQuery"),
+        response: {
+          200: $ref("SessionStreamResponse"),
+        },
+      },
+    },
+    async (
+      request: FastifyRequest<{ Params: { sessionId: string }; Querystring: any }>,
+      reply: FastifyReply,
+    ) =>
+      handleGetSessionStream(
+        server,
+        request as SessionStreamRequest & FastifyRequest<{ Params: { sessionId?: string } }>,
+        reply,
+      ),
   );
 
   server.post(
@@ -172,11 +213,14 @@ async function routes(server: FastifyInstance) {
       },
     },
     async (request: FastifyRequest<{ Body: RecordedEvents }>, reply: FastifyReply) => {
-      server.cdpService.getInstrumentationLogger().record({
-        type: BrowserEventType.Recording,
-        timestamp: new Date().toISOString(),
-        data: request.body,
-      });
+      const sessions = server.sessionService.listSessions();
+      if (sessions.length > 0) {
+        sessions[0].cdpService.getInstrumentationLogger().record({
+          type: BrowserEventType.Recording,
+          timestamp: new Date().toISOString(),
+          data: request.body,
+        });
+      }
       return reply.send({ status: "ok" });
     },
   );
@@ -214,8 +258,13 @@ async function routes(server: FastifyInstance) {
         },
       },
     },
-    async (request: SessionsScrapeRequest, reply: FastifyReply) =>
-      handleScrape(server.sessionService, server.cdpService, request, reply),
+    async (request: SessionsScrapeRequest, reply: FastifyReply) => {
+      const sessions = server.sessionService.listSessions();
+      if (sessions.length === 0) {
+        return reply.code(400).send({ message: "No active sessions" });
+      }
+      return handleScrape(server.sessionService, sessions[0].cdpService, request, reply);
+    },
   );
 
   server.post(
@@ -232,8 +281,13 @@ async function routes(server: FastifyInstance) {
         },
       },
     },
-    async (request: SessionsScreenshotRequest, reply: FastifyReply) =>
-      handleScreenshot(server.sessionService, server.cdpService, request, reply),
+    async (request: SessionsScreenshotRequest, reply: FastifyReply) => {
+      const sessions = server.sessionService.listSessions();
+      if (sessions.length === 0) {
+        return reply.code(400).send({ message: "No active sessions" });
+      }
+      return handleScreenshot(server.sessionService, sessions[0].cdpService, request, reply);
+    },
   );
 
   server.post(
@@ -250,8 +304,13 @@ async function routes(server: FastifyInstance) {
         },
       },
     },
-    async (request: SessionsPDFRequest, reply: FastifyReply) =>
-      handlePDF(server.sessionService, server.cdpService, request, reply),
+    async (request: SessionsPDFRequest, reply: FastifyReply) => {
+      const sessions = server.sessionService.listSessions();
+      if (sessions.length === 0) {
+        return reply.code(400).send({ message: "No active sessions" });
+      }
+      return handlePDF(server.sessionService, sessions[0].cdpService, request, reply);
+    },
   );
 }
 

--- a/api/src/plugins/browser-session.ts
+++ b/api/src/plugins/browser-session.ts
@@ -4,7 +4,7 @@ import { SessionService } from "../services/session.service.js";
 
 const browserSessionPlugin: FastifyPluginAsync = async (fastify, _options) => {
   const sessionService = new SessionService({
-    cdpService: fastify.cdpService,
+    browserPool: fastify.browserPool,
     seleniumService: fastify.seleniumService,
     fileService: fastify.fileService,
     logger: fastify.log,

--- a/api/src/plugins/browser-socket/browser-socket.ts
+++ b/api/src/plugins/browser-socket/browser-socket.ts
@@ -9,19 +9,12 @@ export interface BrowserSocketOptions {
   customHandlers?: WebSocketHandler[];
 }
 
-// WebSocket server instance
 const wss = new WebSocketServer({ noServer: true });
 
 const browserWebSocket: FastifyPluginAsync<BrowserSocketOptions> = async (
   fastify: FastifyInstance,
   options: BrowserSocketOptions,
 ) => {
-  if (!fastify.cdpService.isRunning()) {
-    fastify.log.info("Launching browser...");
-    await fastify.cdpService.launch();
-    fastify.log.info("Browser launched successfully");
-  }
-
   const registry = new WebSocketRegistryService();
 
   defaultHandlers.forEach((handler) => {
@@ -43,27 +36,48 @@ const browserWebSocket: FastifyPluginAsync<BrowserSocketOptions> = async (
       new URL(url || "", `http://${request.headers.host}`).searchParams.entries(),
     );
 
-    const context: WebSocketHandlerContext = {
-      fastify,
-      wss,
-      params,
-    };
+    const matchResult = registry.matchHandlerWithSession(url);
 
-    const handler = registry.matchHandler(url);
+    if (matchResult?.handler) {
+      const context: WebSocketHandlerContext = {
+        fastify,
+        wss,
+        params,
+        sessionId: matchResult.sessionId,
+      };
 
-    if (handler) {
       try {
-        await handler.handler(request, socket, head, context);
+        await matchResult.handler.handler(request, socket, head, context);
       } catch (err) {
         fastify.log.error({ err }, `WebSocket handler error for ${url}`);
         socket.destroy();
       }
+    } else if (matchResult?.sessionId) {
+      const session = fastify.sessionService.getSession(matchResult.sessionId);
+      if (session) {
+        fastify.log.info(`Proxying CDP WebSocket for session ${matchResult.sessionId}`);
+        try {
+          await session.cdpService.proxyWebSocket(request, socket, head);
+        } catch (err) {
+          fastify.log.error({ err }, "Session CDP WebSocket proxy error");
+          socket.destroy();
+        }
+      } else {
+        fastify.log.warn(`Session ${matchResult.sessionId} not found for CDP WebSocket`);
+        socket.destroy();
+      }
     } else {
-      fastify.log.info("Connecting to CDP...");
-      try {
-        await fastify.cdpService.proxyWebSocket(request, socket, head);
-      } catch (err) {
-        fastify.log.error({ err }, "CDP WebSocket error");
+      const sessions = fastify.sessionService.listSessions();
+      if (sessions.length > 0) {
+        fastify.log.info("Proxying CDP WebSocket to first active session (legacy fallback)");
+        try {
+          await sessions[0].cdpService.proxyWebSocket(request, socket, head);
+        } catch (err) {
+          fastify.log.error({ err }, "CDP WebSocket error");
+          socket.destroy();
+        }
+      } else {
+        fastify.log.warn("No active sessions for CDP WebSocket proxy");
         socket.destroy();
       }
     }

--- a/api/src/plugins/browser-socket/casting.handler.ts
+++ b/api/src/plugins/browser-socket/casting.handler.ts
@@ -23,7 +23,8 @@ export async function handleCastSession(
   sessionService: SessionService,
   params: Record<string, string> | undefined,
 ): Promise<void> {
-  const id = request.url?.split("/sessions/")[1].split("/cast")[0];
+  const urlMatch = request.url?.match(/\/v1\/sessions\/([^/?]+)\/cast/);
+  const id = urlMatch?.[1];
 
   if (!id) {
     console.error("Cast Session ID not found");
@@ -31,7 +32,7 @@ export async function handleCastSession(
     return;
   }
 
-  const session = await sessionService.activeSession;
+  const session = sessionService.getSession(id);
   if (!session) {
     console.error(`Cast Session ${id} not found`);
     socket.destroy();
@@ -173,8 +174,14 @@ export async function handleCastSession(
     };
 
     try {
+      const wsEndpoint = session.cdpService.getWsEndpoint();
+      if (!wsEndpoint) {
+        console.error(`No WebSocket endpoint available for session ${id}`);
+        socket.destroy();
+        return;
+      }
       browser = await puppeteer.connect({
-        browserWSEndpoint: `ws://${env.HOST}:${env.PORT}`,
+        browserWSEndpoint: wsEndpoint,
       });
 
       if (!browser) {

--- a/api/src/plugins/browser.ts
+++ b/api/src/plugins/browser.ts
@@ -1,5 +1,4 @@
 import { FastifyPluginAsync } from "fastify";
-import { CDPService } from "../services/cdp/cdp.service.js";
 import fp from "fastify-plugin";
 import { BrowserLauncherOptions } from "../types/index.js";
 import {
@@ -10,9 +9,12 @@ import {
 import path from "path";
 import os from "os";
 import { env } from "../env.js";
+import { BrowserPool } from "../services/browser-pool.service.js";
+import { CDPService } from "../services/cdp/cdp.service.js";
 
 declare module "fastify" {
   interface FastifyInstance {
+    browserPool: BrowserPool;
     cdpService: CDPService;
     registerCDPLaunchHook: (hook: (config: BrowserLauncherOptions) => Promise<void> | void) => void;
     registerCDPShutdownHook: (
@@ -26,52 +28,71 @@ const browserInstancePlugin: FastifyPluginAsync = async (fastify, _options) => {
   const enableStorage = loggingConfig.enableStorage ?? env.LOG_STORAGE_ENABLED ?? false;
   const enableConsoleLogging = loggingConfig.enableConsoleLogging ?? true;
 
-  let storage: LogStorage | null = null;
-  if (enableStorage) {
-    const storagePath =
-      loggingConfig.storagePath ||
-      env.LOG_STORAGE_PATH ||
-      path.join(os.tmpdir(), "steel-browser-logs", "logs.duckdb");
+  function createStorage(): LogStorage {
+    if (enableStorage) {
+      const storagePath =
+        loggingConfig.storagePath ||
+        env.LOG_STORAGE_PATH ||
+        path.join(os.tmpdir(), "steel-browser-logs", "logs.duckdb");
 
-    storage = new DuckDBStorage({
-      dbPath: storagePath,
-      maxThreads: 1,
-      memoryLimit: "128MB",
-      parquetCompression: "none",
-      enableWriteBuffer: true,
-      writeBufferSize: 200,
-      writeBufferFlushInterval: 2000,
-    });
-
-    await storage.initialize();
-    fastify.log.info(`Log storage initialized at ${storagePath}`);
-  } else {
-    // Use in-memory storage for development
-    storage = new InMemoryStorage(1000);
-    await storage.initialize();
-    fastify.log.info("Using in-memory log storage");
+      return new DuckDBStorage({
+        dbPath: storagePath,
+        maxThreads: 1,
+        memoryLimit: "128MB",
+        parquetCompression: "none",
+        enableWriteBuffer: true,
+        writeBufferSize: 200,
+        writeBufferFlushInterval: 2000,
+      });
+    }
+    return new InMemoryStorage(1000);
   }
 
-  const cdpService = new CDPService({}, fastify.log, storage, enableConsoleLogging);
+  const initialStorage = createStorage();
+  await initialStorage.initialize();
+  fastify.log.info(
+    enableStorage ? `Log storage initialized` : "Using in-memory log storage",
+  );
 
-  fastify.decorate("cdpService", cdpService);
+  const browserPool = new BrowserPool(
+    env.MAX_SESSIONS,
+    env.CDP_PORT_BASE,
+    fastify.log,
+    () => {
+      const s = createStorage();
+      s.initialize().catch((err: Error) =>
+        fastify.log.error({ err }, "Failed to initialize slot storage"),
+      );
+      return s;
+    },
+    enableConsoleLogging,
+  );
+
+  fastify.decorate("browserPool", browserPool);
+
+  // Backward-compat: expose the first slot's CDPService as cdpService
+  // so existing routes/handlers that haven't been refactored still work.
+  const defaultSlot = browserPool.getSlotByCdpPort(env.CDP_PORT_BASE);
+  if (defaultSlot) {
+    fastify.decorate("cdpService", defaultSlot.cdpService);
+  }
+
   fastify.decorate(
     "registerCDPLaunchHook",
     (hook: (config: BrowserLauncherOptions) => Promise<void> | void) => {
-      cdpService.registerLaunchHook(hook);
+      if (defaultSlot) {
+        defaultSlot.cdpService.registerLaunchHook(hook);
+      }
     },
   );
   fastify.decorate(
     "registerCDPShutdownHook",
     (hook: (config: BrowserLauncherOptions | null) => Promise<void> | void) => {
-      cdpService.registerShutdownHook(hook);
+      if (defaultSlot) {
+        defaultSlot.cdpService.registerShutdownHook(hook);
+      }
     },
   );
-
-  fastify.addHook("onListen", async function () {
-    this.log.info("Launching default browser...");
-    await cdpService.launch();
-  });
 };
 
 export default fp(browserInstancePlugin, "5.x");

--- a/api/src/services/browser-pool.service.ts
+++ b/api/src/services/browser-pool.service.ts
@@ -1,0 +1,83 @@
+import { FastifyBaseLogger } from "fastify";
+import { CDPService } from "./cdp/cdp.service.js";
+
+export interface PoolSlot {
+  index: number;
+  cdpPort: number;
+  cdpService: CDPService;
+  sessionId: string | null;
+}
+
+export class BrowserPool {
+  private slots: PoolSlot[];
+  private logger: FastifyBaseLogger;
+
+  constructor(
+    maxSessions: number,
+    cdpPortBase: number,
+    logger: FastifyBaseLogger,
+    private storageFactory: () => any,
+    private enableConsoleLogging: boolean,
+  ) {
+    this.logger = logger.child({ component: "BrowserPool" });
+    this.slots = Array.from({ length: maxSessions }, (_, i) => ({
+      index: i,
+      cdpPort: cdpPortBase + i,
+      cdpService: new CDPService(
+        { cdpPort: cdpPortBase + i },
+        logger,
+        storageFactory(),
+        enableConsoleLogging,
+      ),
+      sessionId: null,
+    }));
+    this.logger.info(
+      `[BrowserPool] Initialized with ${maxSessions} slots (ports ${cdpPortBase}-${cdpPortBase + maxSessions - 1})`,
+    );
+  }
+
+  acquire(sessionId: string): PoolSlot | null {
+    const slot = this.slots.find((s) => s.sessionId === null);
+    if (!slot) {
+      this.logger.warn(
+        `[BrowserPool] Pool full — cannot acquire slot for session ${sessionId}`,
+      );
+      return null;
+    }
+    slot.sessionId = sessionId;
+    this.logger.info(
+      `[BrowserPool] Acquired slot ${slot.index} (port ${slot.cdpPort}) for session ${sessionId}`,
+    );
+    return slot;
+  }
+
+  release(sessionId: string): void {
+    const slot = this.slots.find((s) => s.sessionId === sessionId);
+    if (slot) {
+      this.logger.info(
+        `[BrowserPool] Released slot ${slot.index} (port ${slot.cdpPort}) from session ${sessionId}`,
+      );
+      slot.sessionId = null;
+    }
+  }
+
+  getSlot(sessionId: string): PoolSlot | undefined {
+    return this.slots.find((s) => s.sessionId === sessionId);
+  }
+
+  getSlotByCdpPort(port: number): PoolSlot | undefined {
+    return this.slots.find((s) => s.cdpPort === port);
+  }
+
+  get activeCount(): number {
+    return this.slots.filter((s) => s.sessionId !== null).length;
+  }
+
+  get maxSessions(): number {
+    return this.slots.length;
+  }
+
+  getAllActiveSlots(): PoolSlot[] {
+    return this.slots.filter((s) => s.sessionId !== null);
+  }
+}

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -111,16 +111,18 @@ export class CDPService extends EventEmitter {
     | ((req: IncomingMessage, socket: Duplex, head: Buffer) => Promise<void>)
     | null = null;
   private disconnectHandler: () => Promise<void> = () => this.endSession();
+  public readonly cdpPort: number;
 
   constructor(
-    config: { keepAlive?: boolean },
+    config: { keepAlive?: boolean; cdpPort?: number },
     logger: FastifyBaseLogger,
     storage?: any,
     enableConsoleLogging?: boolean,
   ) {
     super();
     this.logger = logger.child({ component: "CDPService" });
-    const { keepAlive = true } = config;
+    const { keepAlive = true, cdpPort = 9222 } = config;
+    this.cdpPort = cdpPort;
 
     this.keepAlive = keepAlive;
     this.browserInstance = null;
@@ -186,6 +188,10 @@ export class CDPService extends EventEmitter {
 
   public getInstrumentationLogger(): BrowserLogger {
     return this.instrumentationLogger;
+  }
+
+  public getWsEndpoint(): string | null {
+    return this.wsEndpoint;
   }
 
   public getLogger(name: string) {
@@ -848,7 +854,7 @@ export class CDPService extends EventEmitter {
         const dynamicArgs = [
           this.launchConfig.dimensions ? "" : "--start-maximized",
           `--remote-debugging-address=${env.HOST}`,
-          "--remote-debugging-port=9222",
+          `--remote-debugging-port=${this.cdpPort}`,
           `--window-size=${this.launchConfig.dimensions?.width ?? 1920},${
             this.launchConfig.dimensions?.height ?? 1080
           }`,

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -9,18 +9,20 @@ import { BrowserFingerprintWithHeaders } from "fingerprint-generator";
 import { CredentialsOptions, SessionDetails } from "../modules/sessions/sessions.schema.js";
 import { BrowserLauncherOptions, OptimizeBandwidthOptions } from "../types/index.js";
 import { IProxyServer, ProxyServer } from "../utils/proxy.js";
-import { getBaseUrl, getUrl } from "../utils/url.js";
+import { getBaseUrl, getUrl, getSessionUrl } from "../utils/url.js";
 import { CDPService } from "./cdp/cdp.service.js";
+import { BrowserPool, PoolSlot } from "./browser-pool.service.js";
 import { CookieData } from "./context/types.js";
 import { FileService } from "./file.service.js";
 import { SeleniumService } from "./selenium.service.js";
 import { TimezoneFetcher } from "./timezone-fetcher.service.js";
 import { deepMerge } from "../utils/context.js";
 
-type Session = SessionDetails & {
+export type Session = SessionDetails & {
   completion: Promise<void>;
   complete: (value: void) => void;
   proxyServer: IProxyServer | undefined;
+  cdpService: CDPService;
 };
 
 const sessionStats = {
@@ -32,54 +34,37 @@ const sessionStats = {
   proxyRxBytes: 0,
 };
 
-const defaultSession = {
-  status: "idle" as SessionDetails["status"],
-  websocketUrl: getBaseUrl("ws"),
-  debugUrl: getUrl("v1/sessions/debug"),
-  debuggerUrl: getUrl("v1/devtools/inspector.html"),
-  sessionViewerUrl: getBaseUrl(),
-  dimensions: { width: 1920, height: 1080 },
-  userAgent: "",
-  isSelenium: false,
-  proxy: "",
-  solveCaptcha: false,
-};
-
 export type ProxyFactory = (proxyUrl: string) => Promise<IProxyServer> | IProxyServer;
 
 export class SessionService {
   private logger: FastifyBaseLogger;
-  private cdpService: CDPService;
+  private browserPool: BrowserPool;
   private seleniumService: SeleniumService;
   private fileService: FileService;
   private timezoneFetcher: TimezoneFetcher;
   public proxyFactory: ProxyFactory = (proxyUrl) => new ProxyServer(proxyUrl);
 
-  public pastSessions: Session[] = [];
-  public activeSession: Session;
+  private sessions = new Map<string, Session>();
 
   constructor(config: {
-    cdpService: CDPService;
+    browserPool: BrowserPool;
     seleniumService: SeleniumService;
     fileService: FileService;
     logger: FastifyBaseLogger;
   }) {
-    this.cdpService = config.cdpService;
+    this.browserPool = config.browserPool;
     this.seleniumService = config.seleniumService;
     this.fileService = config.fileService;
     this.logger = config.logger;
     this.timezoneFetcher = new TimezoneFetcher(config.logger);
-    this.activeSession = {
-      id: uuidv4(),
-      createdAt: new Date().toISOString(),
-      ...defaultSession,
-      ...sessionStats,
-      userAgent: this.cdpService.getUserAgent() ?? "",
-      dimensions: this.cdpService.getDimensions(),
-      completion: Promise.resolve(),
-      complete: () => {},
-      proxyServer: undefined,
-    };
+  }
+
+  public getSession(sessionId: string): Session | null {
+    return this.sessions.get(sessionId) ?? null;
+  }
+
+  public listSessions(): Session[] {
+    return Array.from(this.sessions.values());
   }
 
   public async startSession(options: {
@@ -108,7 +93,6 @@ export class SessionService {
     headless?: boolean;
   }): Promise<SessionDetails> {
     const {
-      sessionId,
       proxyUrl,
       userAgent,
       sessionContext,
@@ -127,7 +111,17 @@ export class SessionService {
       headless,
     } = options;
 
-    // start fetching timezone as early as possible
+    const sessionId = options.sessionId || uuidv4();
+
+    const slot = this.browserPool.acquire(sessionId);
+    if (!slot) {
+      throw new Error(
+        `Session pool is full (max ${this.browserPool.maxSessions} sessions). Release an existing session and retry.`,
+      );
+    }
+
+    const cdpService = slot.cdpService;
+
     let timezonePromise: Promise<string>;
     if (options.timezone) {
       timezonePromise = Promise.resolve(options.timezone);
@@ -138,27 +132,40 @@ export class SessionService {
       );
     }
 
-    // If dimensions not provided, get from CDP service
-    const finalDimensions = dimensions || this.cdpService.getDimensions();
+    const finalDimensions = dimensions || { width: 1920, height: 1080 };
 
-    await this.resetSessionInfo({
-      id: sessionId || uuidv4(),
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const session: Session = {
+      id: sessionId,
+      createdAt: new Date().toISOString(),
       status: "live",
-      proxy: proxyUrl,
-      solveCaptcha: false,
+      websocketUrl: getSessionUrl(sessionId, "cdp", "ws"),
+      debugUrl: getSessionUrl(sessionId, "debug"),
+      debuggerUrl: getUrl("v1/devtools/inspector.html"),
+      sessionViewerUrl: getBaseUrl(),
       dimensions: finalDimensions,
-      isSelenium,
-    });
+      userAgent: "",
+      isSelenium: !!isSelenium,
+      proxy: proxyUrl || "",
+      solveCaptcha: false,
+      ...sessionStats,
+      completion: promise,
+      complete: resolve,
+      proxyServer: undefined,
+      cdpService,
+    };
+
+    this.sessions.set(sessionId, session);
 
     const userDataDir =
       options.userDataDir || options.persist === true
         ? path.join(dirname(fileURLToPath(import.meta.url)), "..", "..", "user-data-dir")
-        : env.CHROME_USER_DATA_DIR || path.join(os.tmpdir(), "steel-chrome");
+        : env.CHROME_USER_DATA_DIR || path.join(os.tmpdir(), `steel-chrome-${sessionId}`);
     await mkdir(userDataDir, { recursive: true });
 
     if (proxyUrl) {
-      this.activeSession.proxyServer = await this.proxyFactory(proxyUrl);
-      await this.activeSession.proxyServer.listen();
+      session.proxyServer = await this.proxyFactory(proxyUrl);
+      await session.proxyServer.listen();
     }
 
     const defaultUserPreferences = {
@@ -172,7 +179,6 @@ export class SessionService {
       ? deepMerge(defaultUserPreferences, userPreferences)
       : defaultUserPreferences;
 
-    // Normalize optimizeBandwidth: true => enable all flags (except lists)
     const normalizeOptimizeBandwidth = (
       value: boolean | OptimizeBandwidthOptions | undefined,
     ): OptimizeBandwidthOptions | undefined => {
@@ -190,7 +196,7 @@ export class SessionService {
     const browserLauncherOptions: BrowserLauncherOptions = {
       options: {
         headless: headless ?? env.CHROME_HEADLESS,
-        proxyUrl: this.activeSession.proxyServer?.url,
+        proxyUrl: session.proxyServer?.url,
       },
       sessionContext,
       userAgent,
@@ -210,88 +216,58 @@ export class SessionService {
     };
 
     if (isSelenium) {
-      await this.cdpService.shutdown();
+      await cdpService.shutdown();
       await this.seleniumService.launch(browserLauncherOptions);
 
-      Object.assign(this.activeSession, {
+      Object.assign(session, {
         websocketUrl: "",
         debugUrl: "",
         sessionViewerUrl: "",
         userAgent:
           userAgent ||
           "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
-        dimensions: this.cdpService.getDimensions(),
       });
-
-      return this.activeSession;
     } else {
-      await this.cdpService.startNewSession(browserLauncherOptions);
+      await cdpService.startNewSession(browserLauncherOptions);
 
-      Object.assign(this.activeSession, {
-        websocketUrl: getBaseUrl("ws"),
-        debugUrl: getUrl("v1/sessions/debug"),
-        debuggerUrl: getUrl("v1/devtools/inspector.html"),
-        sessionViewerUrl: getBaseUrl(),
+      Object.assign(session, {
         userAgent:
-          this.cdpService.getUserAgent() ||
+          cdpService.getUserAgent() ||
           "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
-        dimensions: this.cdpService.getDimensions(),
+        dimensions: cdpService.getDimensions(),
       });
     }
 
-    return this.activeSession;
+    return session;
   }
 
-  public async endSession(): Promise<SessionDetails> {
-    this.activeSession.complete();
-    this.activeSession.status = "released";
-    this.activeSession.duration =
-      new Date().getTime() - new Date(this.activeSession.createdAt).getTime();
-
-    if (this.activeSession.proxyServer) {
-      this.activeSession.proxyTxBytes = this.activeSession.proxyServer.txBytes;
-      this.activeSession.proxyRxBytes = this.activeSession.proxyServer.rxBytes;
+  public async endSession(sessionId: string): Promise<SessionDetails> {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session ${sessionId} not found`);
     }
 
-    if (this.activeSession.isSelenium) {
+    session.complete();
+    session.status = "released";
+    session.duration = Date.now() - new Date(session.createdAt).getTime();
+
+    if (session.proxyServer) {
+      session.proxyTxBytes = session.proxyServer.txBytes;
+      session.proxyRxBytes = session.proxyServer.rxBytes;
+      await session.proxyServer.close(true);
+      session.proxyServer = undefined;
+    }
+
+    if (session.isSelenium) {
       this.seleniumService.close();
-      await this.cdpService.launch();
-    } else {
-      await this.cdpService.endSession();
     }
 
-    const releasedSession = this.activeSession;
+    await session.cdpService.shutdown();
 
-    await this.resetSessionInfo({
-      id: uuidv4(),
-      status: "idle",
-    });
+    this.sessions.delete(sessionId);
+    this.browserPool.release(sessionId);
 
-    this.pastSessions.push(releasedSession);
-
-    return releasedSession;
-  }
-
-  private async resetSessionInfo(overrides?: Partial<SessionDetails>): Promise<SessionDetails> {
-    this.activeSession.complete();
-
-    await this.activeSession.proxyServer?.close(true);
-    this.activeSession.proxyServer = undefined;
-
-    const { promise, resolve } = Promise.withResolvers<void>();
-    this.activeSession = {
-      id: uuidv4(),
-      ...defaultSession,
-      ...overrides,
-      ...sessionStats,
-      userAgent: this.cdpService.getUserAgent() ?? "",
-      createdAt: new Date().toISOString(),
-      completion: promise,
-      complete: resolve,
-      proxyServer: undefined,
-    };
-
-    return this.activeSession;
+    return session;
   }
 
   public setProxyFactory(factory: ProxyFactory) {

--- a/api/src/services/websocket-registry.service.ts
+++ b/api/src/services/websocket-registry.service.ts
@@ -1,5 +1,10 @@
 import { WebSocketHandler, WebSocketHandlerRegistry } from "../types/websocket.js";
 
+export interface MatchResult {
+  handler: WebSocketHandler;
+  sessionId?: string;
+}
+
 export class WebSocketRegistryService implements WebSocketHandlerRegistry {
   public handlers = new Map<string, WebSocketHandler>();
 
@@ -12,13 +17,33 @@ export class WebSocketRegistryService implements WebSocketHandlerRegistry {
   }
 
   matchHandler(url: string): WebSocketHandler | undefined {
-    // TODO: use path-to-regexp or find-my-way to match the path
-    // Find the first handler whose path matches the start of the URL
     for (const [path, handler] of this.handlers.entries()) {
       if (url.startsWith(path)) {
         return handler;
       }
     }
+    return undefined;
+  }
+
+  matchHandlerWithSession(url: string): MatchResult | undefined {
+    const sessionCastMatch = url.match(/\/v1\/sessions\/([^/?]+)\/cast/);
+    if (sessionCastMatch) {
+      const castHandler = this.handlers.get("/v1/sessions/cast");
+      if (castHandler) {
+        return { handler: castHandler, sessionId: sessionCastMatch[1] };
+      }
+    }
+
+    const sessionCdpMatch = url.match(/\/v1\/sessions\/([^/?]+)\/cdp/);
+    if (sessionCdpMatch) {
+      return { handler: undefined as any, sessionId: sessionCdpMatch[1] };
+    }
+
+    const handler = this.matchHandler(url);
+    if (handler) {
+      return { handler };
+    }
+
     return undefined;
   }
 }

--- a/api/src/steel-browser-plugin.ts
+++ b/api/src/steel-browser-plugin.ts
@@ -25,12 +25,14 @@ import type { BrowserLauncherOptions } from "./types/browser.js";
 import { WebSocketHandler } from "./types/websocket.js";
 import { WebSocketRegistryService } from "./services/websocket-registry.service.js";
 import { SessionService } from "./services/session.service.js";
+import { BrowserPool } from "./services/browser-pool.service.js";
 import { LogStorage } from "./services/cdp/instrumentation/storage/log-storage.interface.js";
 
 // We need to redeclare any decorators from within the plugin that we want to expose
 declare module "fastify" {
   interface FastifyInstance {
     steelBrowserConfig: SteelBrowserConfig;
+    browserPool: BrowserPool;
     cdpService: CDPService;
     sessionService: SessionService;
     webSocketRegistry: WebSocketRegistryService;

--- a/api/src/types/fastify.d.ts
+++ b/api/src/types/fastify.d.ts
@@ -4,6 +4,7 @@ import { SessionService } from "../services/session.service.js";
 import { SeleniumService } from "../services/selenium.service.js";
 import { Page } from "puppeteer-core";
 import { FileService } from "../services/file.service.js";
+import { BrowserPool } from "../services/browser-pool.service.js";
 
 declare module "fastify" {
   interface FastifyRequest {}
@@ -11,5 +12,6 @@ declare module "fastify" {
     seleniumService: SeleniumService;
     sessionService: SessionService;
     fileService: FileService;
+    browserPool: BrowserPool;
   }
 }

--- a/api/src/types/websocket.ts
+++ b/api/src/types/websocket.ts
@@ -7,6 +7,7 @@ export interface WebSocketHandlerContext {
   fastify: FastifyInstance;
   wss: WebSocketServer;
   params: Record<string, string>;
+  sessionId?: string;
 }
 
 export interface WebSocketHandler {

--- a/api/src/utils/url.ts
+++ b/api/src/utils/url.ts
@@ -34,6 +34,19 @@ export function getUrl(path: string, protocolType: "http" | "ws" = "http"): stri
 }
 
 /**
+ * Returns a fully qualified URL scoped to a specific session
+ */
+export function getSessionUrl(
+  sessionId: string,
+  path: string,
+  protocolType: "http" | "ws" = "http",
+): string {
+  const base = getBaseUrl(protocolType);
+  const formattedPath = path.startsWith("/") ? path.substring(1) : path;
+  return `${base}v1/sessions/${sessionId}/${formattedPath}`;
+}
+
+/**
  * Normalizes a URL by adding https:// protocol if missing
  * @param url The URL to normalize
  * @returns The normalized URL with proper protocol, or null if invalid

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,9 +8,12 @@ services:
     ports:
       - "3000:3000"
       - "9223:9223"
+    shm_size: "2gb"
     environment:
       - DOMAIN=${DOMAIN:-localhost:3000}
       - CDP_DOMAIN=${CDP_DOMAIN:-localhost:9223}
+      - MAX_SESSIONS=${MAX_SESSIONS:-5}
+      - CDP_PORT_BASE=${CDP_PORT_BASE:-9222}
     volumes:
       - ./.cache:/app/.cache
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     ports:
       - "3000:3000"
       - "9223:9223"
+    shm_size: "2gb"
     volumes:
       - logs:/data/logs
       - exports:/tmp/steel-browser-exports
@@ -13,6 +14,8 @@ services:
       - CDP_DOMAIN=${CDP_DOMAIN:-localhost:9223}
       - LOG_STORAGE_ENABLED=true
       - LOG_STORAGE_PATH=/data/logs/browser-logs.duckdb
+      - MAX_SESSIONS=${MAX_SESSIONS:-5}
+      - CDP_PORT_BASE=${CDP_PORT_BASE:-9222}
     networks:
       - steel-network
 


### PR DESCRIPTION
## Description

Implements browser pool service, concurrent session management, and websocket registry for handling multiple simultaneous browser sessions. Includes updated session routes, CDP service, and docker compose configuration.

## Type of Change

- Added concurency. Details are in README_CONCURENT.md 

## Testing

- [x] I have tested this locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [x] I have tested with Docker
- [x] All existing tests pass

## Breaking Changes

If this is a breaking change, please describe:

1. What breaks: the sessions endpoint now lists all active sessions
2. How users should migrate: reimplement
3. Why this change is necessary: to support concurency and multiple browser sessions
ed 