### PR TITLE
fix: wrap live session script in IIFE to avoid global scope collisions

### DIFF
--- a/api/src/templates/live-session-streamer.ejs
+++ b/api/src/templates/live-session-streamer.ejs
@@ -490,6 +490,7 @@
     </div>
 
     <script>
+    (function() {
           // Global flag for single page mode
           const singlePageMode = <%= singlePageMode %>;
           const interactive = <%= interactive %>;
@@ -1705,6 +1706,7 @@
 
               return ws;
           };
+    })();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Wraps the inline `<script>` block in `live-session-streamer.ejs` with an IIFE
- Prevents top-level variable declarations from colliding with Chrome extension content scripts (e.g. wallet extensions like Rabby that also declare global `pc`)
- Fixes the black screen / `SyntaxError` when viewing live sessions with certain extensions installed

## Changes

Only `api/src/templates/live-session-streamer.ejs` is modified — 2 lines added:
- `(function() {` after `<script>`
- `})();` before `</script>`

## Test plan

- [x] `npm run build` passes (tsc + vite for both api and ui workspaces)
- [x] `npm run lint -w ui` passes
- [x] `npm run pretty -w api` passes
- [ ] Manual: open a live session → player loads (no black screen)
- [ ] Manual: install a Chrome wallet extension (e.g. Rabby) → player still works, no SyntaxError in console

Closes #249