### PR TITLE
perf(metadata): parallelize page title and favicon scraping with Promise.all

### DIFF
--- a/api/src/plugins/browser-socket/casting.handler.ts
+++ b/api/src/plugins/browser-socket/casting.handler.ts
@@ -119,16 +119,17 @@ export async function handleCastSession(
       try {
         if (ws.readyState !== WebSocket.OPEN || !tabDiscoveryMode) return;
 
-        const tabList: PageInfo[] = [];
-
-        for (const [pageId, page] of activePages.entries()) {
-          tabList.push({
-            id: pageId,
-            url: page.url(),
-            title: await getPageTitle(page),
-            favicon: await getPageFavicon(page),
-          });
-        }
+        const tabList: PageInfo[] = await Promise.all(
+          Array.from(activePages.entries()).map(async ([pageId, page]) => {
+            const [title, favicon] = await Promise.all([getPageTitle(page), getPageFavicon(page)]);
+            return {
+              id: pageId,
+              url: page.url(),
+              title,
+              favicon,
+            };
+          }),
+        );
 
         ws.send(
           JSON.stringify({
@@ -406,8 +407,10 @@ export async function handleCastSession(
 
             if (ws.readyState === WebSocket.OPEN) {
               // Get page metadata
-              const title = await getPageTitle(targetPage!);
-              const favicon = await getPageFavicon(targetPage!);
+              const [title, favicon] = await Promise.all([
+                getPageTitle(targetPage!),
+                getPageFavicon(targetPage!),
+              ]);
 
               // Send frame data
               ws.send(


### PR DESCRIPTION
Refactor sequential page title and favicon scraping to run in parallel using Promise.all. This reduces the total I/O wait time when processing multiple pages or multiple metadata fields, significantly improving the performance of the tab list generation and screencast frame updates.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/update

## Related Issues

Closes #(issue number)
Related to #(issue number)

## Changes Made

- [ ] List specific changes made
- [ ] Include any new files or major modifications
- [ ] Mention any removed functionality

## Testing

- [ ] I have tested this locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested with Docker
- [ ] All existing tests pass

## Documentation

- [ ] I have updated relevant documentation
- [ ] I have added JSDoc comments for new public APIs
- [ ] I have updated the README if needed
- [ ] I have updated the CHANGELOG if needed

## Code Quality

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors

## Breaking Changes

If this is a breaking change, please describe:

1. What breaks:
2. How users should migrate:
3. Why this change is necessary:

## Screenshots (if applicable)

Include screenshots or GIFs for UI changes.

## Additional Notes

Any additional information, concerns, or context for reviewers.

---

## Reviewer Checklist

- [ ] Code follows project conventions and style
- [ ] Changes are well-tested
- [ ] Documentation is updated appropriately
- [ ] No security concerns
- [ ] Performance impact is acceptable
- [ ] Breaking changes are properly documented 