### PR TITLE
chore: added typed browser extra and proxy factory interfaces

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -29,6 +29,12 @@
         "types": "./build/services/cdp/instrumentation/storage/log-storage.interface.d.ts",
         "default": "./build/services/cdp/instrumentation/storage/log-storage.interface.js"
       }
+    },
+    "./browser": {
+      "import": {
+        "types": "./build/types/browser.d.ts",
+        "default": "./build/types/browser.js"
+      }
     }
   },
   "scripts": {

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -744,8 +744,7 @@ export class CDPService extends EventEmitter {
             // Check for session extensions passed from the API
             let sessionExtensionPaths: string[] = [];
             if (this.launchConfig!.extra?.orgExtensions?.paths) {
-              sessionExtensionPaths = this.launchConfig!.extra.orgExtensions
-                .paths as unknown as string[];
+              sessionExtensionPaths = this.launchConfig!.extra.orgExtensions.paths;
               this.logger.info(
                 `[CDPService] Found ${sessionExtensionPaths.length} session extension paths`,
               );

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -7,7 +7,11 @@ import { v4 as uuidv4 } from "uuid";
 import { env } from "../env.js";
 import { BrowserFingerprintWithHeaders } from "fingerprint-generator";
 import { CredentialsOptions, SessionDetails } from "../modules/sessions/sessions.schema.js";
-import { BrowserLauncherOptions, OptimizeBandwidthOptions } from "../types/index.js";
+import {
+  BrowserLaunchExtra,
+  BrowserLauncherOptions,
+  OptimizeBandwidthOptions,
+} from "../types/index.js";
 import { IProxyServer, ProxyServer } from "../utils/proxy.js";
 import { getBaseUrl, getUrl } from "../utils/url.js";
 import { CDPService } from "./cdp/cdp.service.js";
@@ -46,7 +50,10 @@ const defaultSession = {
   solveCaptcha: false,
 };
 
-export type ProxyFactory = (proxyUrl: string) => Promise<IProxyServer> | IProxyServer;
+export type ProxyFactory = (
+  proxyUrl: string,
+  options?: OptimizeBandwidthOptions,
+) => Promise<IProxyServer> | IProxyServer;
 
 export class SessionService {
   private logger: FastifyBaseLogger;
@@ -101,7 +108,7 @@ export class SessionService {
     extensions?: string[];
     timezone?: string;
     dimensions?: { width: number; height: number };
-    extra?: Record<string, Record<string, string>>;
+    extra?: BrowserLaunchExtra;
     credentials: CredentialsOptions;
     skipFingerprintInjection?: boolean;
     userPreferences?: Record<string, any>;
@@ -170,11 +177,6 @@ export class SessionService {
         : env.CHROME_USER_DATA_DIR || path.join(os.tmpdir(), "steel-chrome");
     await mkdir(userDataDir, { recursive: true });
 
-    if (proxyUrl) {
-      this.activeSession.proxyServer = await this.proxyFactory(proxyUrl);
-      await this.activeSession.proxyServer.listen();
-    }
-
     const defaultUserPreferences = {
       plugins: {
         always_open_pdf_externally: true,
@@ -200,6 +202,11 @@ export class SessionService {
     };
 
     const normalizedOptimize = normalizeOptimizeBandwidth(optimizeBandwidth);
+
+    if (proxyUrl) {
+      this.activeSession.proxyServer = await this.proxyFactory(proxyUrl, normalizedOptimize);
+      await this.activeSession.proxyServer.listen();
+    }
 
     const browserLauncherOptions: BrowserLauncherOptions = {
       options: {

--- a/api/src/types/browser.ts
+++ b/api/src/types/browser.ts
@@ -16,10 +16,12 @@ export interface OptimizeBandwidthOptions {
   blockUrlPatterns?: string[];
 }
 
+export interface BrowserOrgExtensionsExtra {
+  paths?: string[];
+}
+
 export interface BrowserLaunchExtra {
-  orgExtensions?: {
-    paths?: string[];
-  };
+  orgExtensions?: BrowserOrgExtensionsExtra;
   [key: string]: unknown;
 }
 

--- a/api/src/types/browser.ts
+++ b/api/src/types/browser.ts
@@ -8,13 +8,20 @@ import type {
 import { BrowserFingerprintWithHeaders } from "fingerprint-generator";
 import type { CredentialsOptions } from "../modules/sessions/sessions.schema.js";
 
-export type OptimizeBandwidthOptions = {
+export interface OptimizeBandwidthOptions {
   blockImages?: boolean;
   blockMedia?: boolean;
   blockStylesheets?: boolean;
   blockHosts?: string[];
   blockUrlPatterns?: string[];
-};
+}
+
+export interface BrowserLaunchExtra {
+  orgExtensions?: {
+    paths?: string[];
+  };
+  [key: string]: unknown;
+}
 
 export interface BrowserLauncherOptions {
   options: BrowserServerOptions;
@@ -40,7 +47,7 @@ export interface BrowserLauncherOptions {
   } | null;
   userDataDir?: string;
   userPreferences?: Record<string, any>;
-  extra?: Record<string, Record<string, string>>;
+  extra?: BrowserLaunchExtra;
   credentials?: CredentialsOptions;
   skipFingerprintInjection?: boolean;
   deviceConfig?: { device: "desktop" | "mobile" };


### PR DESCRIPTION
Adds a public `@steel-browser/api/browser` export with an augmentable `BrowserLaunchExtra` interface so consumers can type `BrowserLauncherOptions.extra` safely via module augmentation. Also updates `ProxyFactory` to accept normalized `OptimizeBandwidthOptions` during session startup and preserves core `orgExtensions.paths` typing inside steel-browser.