### PR TITLE
fix: add changeOrigin to CDP WebSocket proxy to fix self-hosted domain connections

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -1114,6 +1114,7 @@ export class CDPService extends EventEmitter {
       head,
       {
         target: this.wsEndpoint,
+        changeOrigin: true,
       },
       (error) => {
         if (error) {


### PR DESCRIPTION
## Summary

The CDP WebSocket proxy in `proxyWebSocket()` fails with 500 when connecting via a domain name (e.g., `steel-browser.railway.internal`) in self-hosted deployments. Chrome rejects WebSocket connections where the `Host` header is not `localhost` or an IP address.

## Root Cause

The `http-proxy` `wsProxyServer.ws()` call forwards the original request headers — including the `Host` header — to Chrome's DevTools endpoint. Chrome checks that `Host` is `localhost` or an IP, and returns an error otherwise.

The fix adds `changeOrigin: true` to the proxy options, which instructs `http-proxy` to rewrite the `Host` header to match the target (e.g., `127.0.0.1:9222`).

## Evidence

The same `changeOrigin: true` pattern is already used correctly in the UI's Vite proxy configuration:

https://github.com/steel-dev/steel-browser/blob/main/ui/vite.config.ts#L18

## Reproduction

1. Self-host Steel Browser behind a reverse proxy with a domain name (e.g., Railway internal domain)
2. Create a session via `POST /v1/sessions`
3. Attempt to connect via CDP WebSocket at `ws://<domain>:8080/`
4. Chrome rejects with: `Host header is specified and is not an IP address or localhost`
5. Puppeteer receives `Unexpected server response: 500`

## Fix

```diff
 this.wsProxyServer.ws(req, socket, head, {
     target: this.wsEndpoint,
+    changeOrigin: true,
 }, (error) => { ... });
```

## Related

- [Issue #295](https://github.com/steel-dev/steel-browser/issues/295) — fingerprint generation bug (separate issue, worked around with `SKIP_FINGERPRINT_INJECTION=true`)
- [Issue #222](https://github.com/steel-dev/steel-browser/issues/222) — possibly related CDP/WebSocket errors in self-hosted deployments