### PR TITLE
fix: relax default desktop fingerprint screen range

### DIFF
--- a/api/src/services/cdp/cdp.service.test.ts
+++ b/api/src/services/cdp/cdp.service.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildFingerprintOptions } from "./cdp.service.js";
+
+describe("buildFingerprintOptions", () => {
+  it("uses a range for the default desktop fingerprint screen", () => {
+    const options = buildFingerprintOptions({
+      dimensions: { width: 1920, height: 1080 },
+    } as any);
+
+    expect(options.screen).toEqual({
+      minWidth: 1280,
+      minHeight: 720,
+      maxWidth: 2560,
+      maxHeight: 1440,
+    });
+  });
+
+  it("keeps non-default custom desktop dimensions exact", () => {
+    const options = buildFingerprintOptions({
+      dimensions: { width: 1440, height: 900 },
+    } as any);
+
+    expect(options.screen).toEqual({
+      minWidth: 1440,
+      minHeight: 900,
+      maxWidth: 1440,
+      maxHeight: 900,
+    });
+  });
+
+  it("keeps mobile fingerprint generation unconstrained by desktop screen", () => {
+    const options = buildFingerprintOptions({
+      deviceConfig: { device: "mobile" },
+      dimensions: { width: 1920, height: 1080 },
+    } as any);
+
+    expect(options).toEqual({
+      devices: ["mobile"],
+      locales: ["en-US", "en"],
+    });
+  });
+});

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -80,6 +80,46 @@ import {
 import { executeBestEffort, executeCritical, executeOptional } from "./utils/error-handlers.js";
 import { TimezoneFetcher } from "../timezone-fetcher.service.js";
 
+const DEFAULT_DESKTOP_WIDTH = 1920;
+const DEFAULT_DESKTOP_HEIGHT = 1080;
+const DEFAULT_DESKTOP_FINGERPRINT_SCREEN = {
+  minWidth: 1280,
+  minHeight: 720,
+  maxWidth: 2560,
+  maxHeight: 1440,
+};
+
+export function buildFingerprintOptions(
+  launchConfig: BrowserLauncherOptions,
+): Partial<FingerprintGeneratorOptions> {
+  if (launchConfig.deviceConfig?.device === "mobile") {
+    return {
+      devices: ["mobile"],
+      locales: ["en-US", "en"],
+    };
+  }
+
+  const dimensions = launchConfig.dimensions;
+  const isDefaultDesktopSize =
+    !dimensions ||
+    (dimensions.width === DEFAULT_DESKTOP_WIDTH && dimensions.height === DEFAULT_DESKTOP_HEIGHT);
+
+  return {
+    devices: ["desktop"],
+    operatingSystems: ["linux"],
+    browsers: [{ name: "chrome", minVersion: 146 }],
+    locales: ["en-US", "en"],
+    screen: isDefaultDesktopSize
+      ? DEFAULT_DESKTOP_FINGERPRINT_SCREEN
+      : {
+          minWidth: dimensions.width,
+          minHeight: dimensions.height,
+          maxWidth: dimensions.width,
+          maxHeight: dimensions.height,
+        },
+  };
+}
+
 export class CDPService extends EventEmitter {
   private logger: FastifyBaseLogger;
   private keepAlive: boolean;
@@ -681,26 +721,7 @@ export class CDPService extends EventEmitter {
         ) {
           await executeCritical(
             async () => {
-              let fingerprintOptions: Partial<FingerprintGeneratorOptions> = {
-                devices: ["desktop"],
-                operatingSystems: ["linux"],
-                browsers: [{ name: "chrome", minVersion: 146 }],
-                locales: ["en-US", "en"],
-                screen: {
-                  minWidth: this.launchConfig!.dimensions?.width ?? 1920,
-                  minHeight: this.launchConfig!.dimensions?.height ?? 1080,
-                  maxWidth: this.launchConfig!.dimensions?.width ?? 1920,
-                  maxHeight: this.launchConfig!.dimensions?.height ?? 1080,
-                },
-              };
-
-              if (this.launchConfig!.deviceConfig?.device === "mobile") {
-                fingerprintOptions = {
-                  devices: ["mobile"],
-                  locales: ["en-US", "en"],
-                };
-              }
-
+              const fingerprintOptions = buildFingerprintOptions(this.launchConfig!);
               const fingerprintGen = new FingerprintGenerator(fingerprintOptions);
               this.fingerprintData = fingerprintGen.getFingerprint();
             },


### PR DESCRIPTION
## Summary
- move CDP fingerprint option construction into a small testable helper
- relax the default 1920x1080 desktop fingerprint constraint to a 1280x720-2560x1440 range so Chrome 146 samples can be selected
- preserve exact screen constraints for non-default custom desktop dimensions and keep mobile generation unconstrained by desktop screen size

Fixes #294.

## Verification
- npm run build -w api
- npx vitest run src/services/cdp/cdp.service.test.ts