### PR TITLE
fix(sessions): forward fullscreen option to session service

### DIFF
--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -31,6 +31,7 @@ export const handleLaunchBrowserSession = async (
       userPreferences,
       deviceConfig,
       headless,
+      fullscreen,
     } = request.body;
 
     return await server.sessionService.startSession({
@@ -56,6 +57,7 @@ export const handleLaunchBrowserSession = async (
       userPreferences,
       deviceConfig,
       headless,
+      fullscreen,
     });
   } catch (e: unknown) {
     server.log.error({ err: e }, "Failed lauching browser session");


### PR DESCRIPTION
## Summary

The `fullscreen` session option was defined in the request schema and supported by downstream services, but it was not being forwarded from `handleLaunchBrowserSession` to `SessionService`.

As a result, requests such as `POST /v1/sessions` with `{ "fullscreen": true }` were silently ignored, and the browser was launched without applying the expected `--kiosk` mode.

---

## Root Cause

The controller did not extract `fullscreen` from `request.body`, so the value was never passed into `SessionService.startSession`. This caused the option to be dropped before reaching the browser launch layer.

---

## Fix

`fullscreen` is now explicitly forwarded through the controller, matching the same pass-through pattern used for other session options like `headless` and `deviceConfig`.

---

## Impact

- Fixes missing `fullscreen` behavior in session creation API
- Ensures `--kiosk` mode is applied when requested
- No changes to existing defaults or other session options

---

## Testing

- Verified locally with `fullscreen: true`
- Confirmed browser launches in kiosk mode
- All existing tests pass