### PR TITLE
fix(sessions): respect caller-supplied userDataDir

### DIFF
--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -174,9 +174,10 @@ export class SessionService {
     });
 
     const userDataDir =
-      options.userDataDir || options.persist === true
+      options.userDataDir ||
+      (options.persist === true
         ? path.join(dirname(fileURLToPath(import.meta.url)), "..", "..", "user-data-dir")
-        : env.CHROME_USER_DATA_DIR || path.join(os.tmpdir(), "steel-chrome");
+        : env.CHROME_USER_DATA_DIR || path.join(os.tmpdir(), "steel-chrome"));
     await mkdir(userDataDir, { recursive: true });
 
     const defaultUserPreferences = {


### PR DESCRIPTION
## Summary

There is a precedence issue in the session launch configuration where the expression combining `userDataDir`, `persist`, and the default storage path does not behave as intended.

Due to operator precedence, `userDataDir` was only being evaluated for truthiness inside the conditional chain, rather than being properly selected as the highest-priority value. As a result, even when a caller explicitly provided `userDataDir`, Chrome could still fall back to the default persistent directory.

---

## Fix

This change adjusts the evaluation order so that `userDataDir` is correctly prioritized before any fallback to `persist` or the default storage path.

The behavior is now:

1. If `userDataDir` is provided → it is used directly
2. Else if `persist === true` → persistent profile directory is used
3. Otherwise → default ephemeral directory is used

---

## Impact

- Fixes incorrect directory selection when `userDataDir` is explicitly provided
- Ensures caller-specified paths are respected
- Preserves existing behavior for `persist` and default mode

---

## Testing

- Verified locally with different combinations of:
  - `userDataDir` set
  - `persist: true`
  - default configuration
- All existing tests pass