### PR TITLE
feat(sessions): introduce configuration resolver layer to prevent opt…

### DIFF
--- a/api/src/modules/sessions/session-config.resolver.test.ts
+++ b/api/src/modules/sessions/session-config.resolver.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { resolveSessionConfig } from "./session-config.resolver.js";
+import type { CreateSessionBody } from "./sessions.schema.js";
+
+describe("resolveSessionConfig", () => {
+  it("preserves the fullscreen option", () => {
+    const config = resolveSessionConfig({ fullscreen: true } as CreateSessionBody);
+    expect(config.fullscreen).toBe(true);
+  });
+
+  it("preserves the userDataDir option", () => {
+    const config = resolveSessionConfig({ userDataDir: "/tmp/custom" } as CreateSessionBody);
+    expect(config.userDataDir).toBe("/tmp/custom");
+  });
+
+  it("does not drop any field present on the request body", () => {
+    const body = {
+      sessionId: "11111111-1111-1111-1111-111111111111",
+      proxyUrl: "http://proxy.local:8080",
+      userAgent: "steel-test-agent",
+      sessionContext: { cookies: [] },
+      isSelenium: true,
+      blockAds: true,
+      optimizeBandwidth: true,
+      skipFingerprintInjection: true,
+      deviceConfig: { device: "mobile" },
+      fullscreen: true,
+      logSinkUrl: "http://logs.local",
+      extensions: ["ext-a"],
+      persist: true,
+      userDataDir: "/tmp/custom",
+      timezone: "UTC",
+      dimensions: { width: 1280, height: 720 },
+      userPreferences: { foo: "bar" },
+      extra: { trace: "abc" },
+      credentials: { autoSubmit: true },
+      headless: false,
+    } as unknown as CreateSessionBody;
+
+    const config = resolveSessionConfig(body);
+
+    // Every key supplied on the body must survive resolution unchanged.
+    for (const key of Object.keys(body) as (keyof CreateSessionBody)[]) {
+      expect(config).toHaveProperty(key);
+      expect(config[key as keyof typeof config]).toEqual(body[key]);
+    }
+  });
+
+  it("forwards new/unknown fields without per-field maintenance", () => {
+    const body = { someFutureOption: "kept" } as unknown as CreateSessionBody;
+    const config = resolveSessionConfig(body) as Record<string, unknown>;
+    expect(config.someFutureOption).toBe("kept");
+  });
+});

--- a/api/src/modules/sessions/session-config.resolver.ts
+++ b/api/src/modules/sessions/session-config.resolver.ts
@@ -1,0 +1,39 @@
+import type { SessionService } from "../../services/session.service.js";
+import { CreateSessionBody } from "./sessions.schema.js";
+
+/**
+ * The normalized configuration object consumed by {@link SessionService.startSession}.
+ *
+ * It is derived directly from the service signature so that the compiler enforces
+ * that anything produced by the resolver remains a valid session input. If the
+ * service ever requires a new field, resolution will fail to type-check instead of
+ * silently launching a session with missing options.
+ */
+export type SessionConfig = Parameters<SessionService["startSession"]>[0];
+
+/**
+ * Resolve a raw `CreateSession` request body into a single, fully-populated
+ * {@link SessionConfig}.
+ *
+ * Historically the controller mapped the request body onto the service input via
+ * manual destructuring. Every new option had to be threaded through by hand, and
+ * forgetting to do so silently dropped the field on the floor (see the recurring
+ * `fullscreen` / `userDataDir` regressions). This resolver removes that failure
+ * mode: it forwards the validated body wholesale, so any field accepted by the
+ * schema is preserved without per-field maintenance.
+ *
+ * Only normalization that the service input genuinely requires is applied here —
+ * namely reconciling the `sessionContext` shape. No business logic lives in this
+ * layer; it is a pure, side-effect-free transformation.
+ */
+export function resolveSessionConfig(body: CreateSessionBody): SessionConfig {
+  return {
+    // Forward every validated field so options can never be silently dropped.
+    ...body,
+    // Reconcile the schema's session context shape with the service input type.
+    sessionContext: body.sessionContext as SessionConfig["sessionContext"],
+    // `credentials` is a required key on the service input; keep it explicit so
+    // the resolved config always satisfies the contract.
+    credentials: body.credentials,
+  };
+}

--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -2,7 +2,7 @@ import { CDPService } from "../../services/cdp/cdp.service.js";
 import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { getErrors } from "../../utils/errors.js";
 import { CreateSessionRequest, SessionDetails, SessionStreamRequest } from "./sessions.schema.js";
-import { CookieData } from "../../services/context/types.js";
+import { resolveSessionConfig } from "./session-config.resolver.js";
 import { getUrl, getBaseUrl } from "../../utils/url.js";
 
 export const handleLaunchBrowserSession = async (
@@ -11,52 +11,9 @@ export const handleLaunchBrowserSession = async (
   reply: FastifyReply,
 ) => {
   try {
-    const {
-      sessionId,
-      proxyUrl,
-      userDataDir,
-      persist,
-      userAgent,
-      sessionContext,
-      extensions,
-      logSinkUrl,
-      timezone,
-      dimensions,
-      isSelenium,
-      blockAds,
-      optimizeBandwidth,
-      extra,
-      credentials,
-      skipFingerprintInjection,
-      userPreferences,
-      deviceConfig,
-      headless,
-    } = request.body;
+    const config = resolveSessionConfig(request.body);
 
-    return await server.sessionService.startSession({
-      sessionId,
-      proxyUrl,
-      userDataDir,
-      persist,
-      userAgent,
-      sessionContext: sessionContext as {
-        cookies?: CookieData[] | undefined;
-        localStorage?: Record<string, Record<string, any>> | undefined;
-      },
-      extensions,
-      logSinkUrl,
-      timezone,
-      dimensions,
-      isSelenium,
-      blockAds,
-      optimizeBandwidth,
-      extra,
-      credentials,
-      skipFingerprintInjection,
-      userPreferences,
-      deviceConfig,
-      headless,
-    });
+    return await server.sessionService.startSession(config);
   } catch (e: unknown) {
     server.log.error({ err: e }, "Failed lauching browser session");
     const error = getErrors(e);


### PR DESCRIPTION
## Summary

This PR introduces a `resolveSessionConfig` layer that replaces manual per-field destructuring in `sessions.controller.ts`.

Instead of manually forwarding each session option, the controller now delegates to a resolver that passes the validated request body to `SessionService`.

This ensures that all fields defined in the `CreateSession` schema are preserved automatically, preventing silent option loss when new fields are added.

---

## Changes

- Add `session-config.resolver.ts` (pure config transformation layer)
- Replace manual destructuring in `sessions.controller.ts` with `resolveSessionConfig()`
- Add unit tests to ensure field preservation (including `fullscreen`, `userDataDir`)

---

## Why this change

Previously, session options were manually mapped in the controller. This caused a risk where newly added schema fields were not forwarded to the service layer, resulting in silent failures.

This abstraction removes that maintenance burden and ensures schema → service consistency.

---

## Testing

- All existing tests pass
- Unit tests added for resolver
- TypeScript compilation passes (`tsc --noEmit`)