### PR TITLE
fix(cdp): fall back to older Chrome minVersion when fingerprint generation fails

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -701,8 +701,55 @@ export class CDPService extends EventEmitter {
                 };
               }
 
-              const fingerprintGen = new FingerprintGenerator(fingerprintOptions);
-              this.fingerprintData = fingerprintGen.getFingerprint();
+              // The bundled fingerprint-generator dataset does not always have
+              // samples for the newest Chrome at the requested screen box (e.g.
+              // Chrome 146 has none at a fixed 1920x1080), which makes
+              // getFingerprint() throw and fails the entire browser launch.
+              // Retry with progressively older minVersions so a missing newest
+              // sample degrades to a slightly older real fingerprint instead of
+              // a hard launch failure.
+              const requestedBrowser = fingerprintOptions.browsers?.[0];
+              const requestedMinVersion =
+                requestedBrowser && typeof requestedBrowser === "object"
+                  ? requestedBrowser.minVersion
+                  : undefined;
+              const minVersionFallbacks = [
+                requestedMinVersion,
+                ...[144, 140, 136, undefined].filter(
+                  (version) =>
+                    requestedMinVersion === undefined ||
+                    version === undefined ||
+                    version < requestedMinVersion,
+                ),
+              ];
+
+              let lastError: unknown;
+              for (const minVersion of minVersionFallbacks) {
+                const attemptOptions =
+                  fingerprintOptions.browsers && minVersion !== undefined
+                    ? {
+                        ...fingerprintOptions,
+                        browsers: [{ name: "chrome", minVersion }],
+                      }
+                    : fingerprintOptions;
+                try {
+                  this.fingerprintData = new FingerprintGenerator(
+                    attemptOptions,
+                  ).getFingerprint();
+                  if (minVersion !== requestedMinVersion) {
+                    this.logger.warn(
+                      `[CDPService] No fingerprint sample for the requested Chrome version; fell back to minVersion ${minVersion ?? "any"}`,
+                    );
+                  }
+                  lastError = undefined;
+                  break;
+                } catch (generationError) {
+                  lastError = generationError;
+                }
+              }
+              if (lastError) {
+                throw lastError;
+              }
             },
             (error) => {
               this.logger.error({ err: error }, "[CDPService] Error generating fingerprint");


### PR DESCRIPTION
## Problem

With fingerprint injection enabled, self-hosted `steel-browser-api` (v0.5.3, `fingerprint-generator@2.1.82`) fails **every** browser launch:

```
Fingerprint error during generation: Failed to generate a consistent fingerprint after 10 attempts
[CDPService] LAUNCH ERROR (FINGERPRINT)
Failed after 3 attempts
```

The only workaround is `SKIP_FINGERPRINT_INJECTION=true`, which disables anti-detection entirely (navigator.webdriver exposed, no fingerprint spoofing) and gets sessions blocked by Cloudflare managed challenges.

Closes #302 (also addresses #294, #295).

## Root cause

In `cdp.service.ts` the desktop fingerprint options hardcode `minVersion: 146` with a **fixed** screen box (`minWidth === maxWidth === 1920`, `minHeight === maxHeight === 1080`). The bundled dataset has no Chrome 146 desktop-Linux samples at any resolution ≤ 1920×1080, so the generator exhausts its retries and throws — which `executeCritical` turns into a fatal launch error.

Verified in-container:

```js
const opts = (screen) => ({
  devices:["desktop"], operatingSystems:["linux"],
  browsers:[{name:"chrome",minVersion:146}], locales:["en-US","en"], screen,
});
new FingerprintGenerator(opts({minWidth:1920,minHeight:1080,maxWidth:1920,maxHeight:1080})).getFingerprint(); // FAIL
new FingerprintGenerator({...opts({minWidth:1920,minHeight:1080,maxWidth:1920,maxHeight:1080}), browsers:[{name:"chrome",minVersion:144}]}).getFingerprint(); // OK
```

## Fix

Make generation resilient instead of fatal: try the requested options first, then on failure retry with progressively older `minVersion`s (`144 → 140 → 136 → any`) before giving up. When the dataset has the newest Chrome, nothing changes; when it doesn't, the launch degrades to a slightly older **real** fingerprint instead of crashing.

- Preserves existing behavior on datasets that do have current samples.
- No API or config change required.
- Mobile path and the requested screen box are untouched.

## Testing

Applied on a 10-container self-hosted deployment. Before: 100% launch failure with injection on. After: browsers launch with injection active, and sessions pass Cloudflare **managed** challenges natively (no external solver, no cookie transplant) — which was impossible with `SKIP_FINGERPRINT_INJECTION=true`.
