### PR TITLE
fix(self-host): avoid wildcard session urls

### DIFF
--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -8,6 +8,7 @@ const envSchema = z.object({
     .enum(["test", "development", "staging", "production", "preview"])
     .default("development"),
   HOST: z.string().optional().default("0.0.0.0"),
+  HOST_IP: z.string().optional().default("localhost"),
   DOMAIN: z.string().optional(),
   PORT: z.string().optional().default("3000"),
   USE_SSL: z

--- a/api/src/modules/sessions/sessions.controller.test.ts
+++ b/api/src/modules/sessions/sessions.controller.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { handleLaunchBrowserSession } from "./sessions.controller.js";
+
+describe("handleLaunchBrowserSession", () => {
+  it("returns request-scoped public urls for launched sessions", async () => {
+    const startSession = vi.fn().mockResolvedValue({
+      id: "session-1",
+      websocketUrl: "ws://localhost:3000/",
+      debugUrl: "http://localhost:3000/v1/sessions/debug",
+      debuggerUrl: "http://localhost:3000/v1/devtools/inspector.html",
+      sessionViewerUrl: "http://localhost:3000/",
+      createdAt: new Date().toISOString(),
+      status: "live",
+      duration: 0,
+      eventCount: 0,
+      timeout: 0,
+      creditsUsed: 0,
+      userAgent: "ua",
+      proxy: "",
+      proxyTxBytes: 0,
+      proxyRxBytes: 0,
+      solveCaptcha: false,
+      isSelenium: false,
+    });
+
+    const server = {
+      sessionService: { startSession },
+      log: { error: vi.fn() },
+    } as any;
+
+    const request = {
+      body: {
+        sessionId: "session-1",
+      },
+      headers: {
+        host: "steel.example.com",
+        "x-forwarded-proto": "https",
+      },
+    } as any;
+
+    const reply = {
+      code: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    } as any;
+
+    const result = await handleLaunchBrowserSession(server, request, reply);
+
+    expect(startSession).toHaveBeenCalledOnce();
+    expect(result.websocketUrl).toBe("wss://steel.example.com/");
+    expect(result.debugUrl).toBe("https://steel.example.com/v1/sessions/debug");
+    expect(result.debuggerUrl).toBe("https://steel.example.com/v1/devtools/inspector.html");
+    expect(result.sessionViewerUrl).toBe("https://steel.example.com/");
+  });
+});

--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -33,7 +33,7 @@ export const handleLaunchBrowserSession = async (
       headless,
     } = request.body;
 
-    return await server.sessionService.startSession({
+    const session = await server.sessionService.startSession({
       sessionId,
       proxyUrl,
       userDataDir,
@@ -57,6 +57,14 @@ export const handleLaunchBrowserSession = async (
       deviceConfig,
       headless,
     });
+
+    return {
+      ...session,
+      websocketUrl: getBaseUrlFromRequest(request, "ws"),
+      debugUrl: getUrlFromRequest(request, "v1/sessions/debug"),
+      debuggerUrl: getUrlFromRequest(request, "v1/devtools/inspector.html"),
+      sessionViewerUrl: getBaseUrlFromRequest(request),
+    };
   } catch (e: unknown) {
     server.log.error({ err: e }, "Failed lauching browser session");
     const error = getErrors(e);

--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -3,7 +3,7 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { getErrors } from "../../utils/errors.js";
 import { CreateSessionRequest, SessionDetails, SessionStreamRequest } from "./sessions.schema.js";
 import { CookieData } from "../../services/context/types.js";
-import { getUrl, getBaseUrl } from "../../utils/url.js";
+import { getUrl, getBaseUrl, getBaseUrlFromRequest, getUrlFromRequest } from "../../utils/url.js";
 
 export const handleLaunchBrowserSession = async (
   server: FastifyInstance,
@@ -94,6 +94,13 @@ export const handleGetSessionDetails = async (
   reply: FastifyReply,
 ) => {
   const sessionId = request.params.sessionId;
+  const requestScopedUrls = {
+    websocketUrl: getBaseUrlFromRequest(request, "ws"),
+    debugUrl: getUrlFromRequest(request, "v1/sessions/debug"),
+    debuggerUrl: getUrlFromRequest(request, "v1/devtools/inspector.html"),
+    sessionViewerUrl: getBaseUrlFromRequest(request),
+  };
+
   if (sessionId !== server.sessionService.activeSession.id) {
     return reply.send({
       id: sessionId,
@@ -103,10 +110,7 @@ export const handleGetSessionDetails = async (
       eventCount: 0,
       timeout: 0,
       creditsUsed: 0,
-      websocketUrl: getBaseUrl("ws"),
-      debugUrl: getUrl("v1/sessions/debug"),
-      debuggerUrl: getUrl("v1/devtools/inspector.html"),
-      sessionViewerUrl: getBaseUrl(),
+      ...requestScopedUrls,
       userAgent: "",
       isSelenium: false,
       proxy: "",
@@ -121,6 +125,7 @@ export const handleGetSessionDetails = async (
   console.log("duration", duration);
   return reply.send({
     ...session,
+    ...requestScopedUrls,
     duration,
   });
 };
@@ -132,6 +137,10 @@ export const handleGetSessions = async (
 ) => {
   const currentSession = {
     ...server.sessionService.activeSession,
+    websocketUrl: getBaseUrlFromRequest(request, "ws"),
+    debugUrl: getUrlFromRequest(request, "v1/sessions/debug"),
+    debuggerUrl: getUrlFromRequest(request, "v1/devtools/inspector.html"),
+    sessionViewerUrl: getBaseUrlFromRequest(request),
     duration:
       new Date().getTime() - new Date(server.sessionService.activeSession.createdAt).getTime(),
   };
@@ -229,9 +238,9 @@ export const handleGetSessionLiveDetails = async (
     return reply.send({
       pages: validPagesInfo,
       browserState,
-      websocketUrl: server.sessionService.activeSession.websocketUrl,
-      sessionViewerUrl: server.sessionService.activeSession.sessionViewerUrl,
-      sessionViewerFullscreenUrl: `${server.sessionService.activeSession.sessionViewerUrl}?showControls=false`,
+      websocketUrl: getBaseUrlFromRequest(request, "ws"),
+      sessionViewerUrl: getBaseUrlFromRequest(request),
+      sessionViewerFullscreenUrl: `${getBaseUrlFromRequest(request)}?showControls=false`,
     });
   } catch (error) {
     console.error("Error getting session state:", error);

--- a/api/src/plugins/browser-socket/casting.handler.ts
+++ b/api/src/plugins/browser-socket/casting.handler.ts
@@ -4,6 +4,7 @@ import { Duplex } from "stream";
 import WebSocket, { Server } from "ws";
 
 import { env } from "../../env.js";
+import { getInternalHost } from "../../utils/url.js";
 import { SessionService } from "../../services/session.service.js";
 import {
   CloseTabEvent,
@@ -174,7 +175,7 @@ export async function handleCastSession(
 
     try {
       browser = await puppeteer.connect({
-        browserWSEndpoint: `ws://${env.HOST}:${env.PORT}`,
+        browserWSEndpoint: `ws://${getInternalHost()}:${env.PORT}`,
       });
 
       if (!browser) {

--- a/api/src/utils/url.test.ts
+++ b/api/src/utils/url.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("url helpers", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("uses localhost instead of 0.0.0.0 for default public base urls", async () => {
+    vi.stubEnv("HOST", "0.0.0.0");
+    vi.stubEnv("PORT", "3000");
+    vi.stubEnv("USE_SSL", "false");
+    vi.stubEnv("DOMAIN", "");
+
+    const { getBaseUrl, getUrl, getInternalHost } = await import("./url.js");
+
+    expect(getBaseUrl()).toBe("http://localhost:3000/");
+    expect(getBaseUrl("ws")).toBe("ws://localhost:3000/");
+    expect(getUrl("v1/sessions/debug")).toBe("http://localhost:3000/v1/sessions/debug");
+    expect(getInternalHost()).toBe("localhost");
+  });
+
+  it("prefers x-forwarded-host and upgrades websocket protocol from forwarded https", async () => {
+    vi.stubEnv("HOST", "0.0.0.0");
+    vi.stubEnv("PORT", "3000");
+    vi.stubEnv("USE_SSL", "false");
+    vi.stubEnv("DOMAIN", "");
+
+    const { getBaseUrlFromRequest, getUrlFromRequest } = await import("./url.js");
+
+    const request = {
+      headers: {
+        host: "localhost:3000",
+        "x-forwarded-host": "public.steel.dev",
+        "x-forwarded-proto": "https",
+      },
+    } as any;
+
+    expect(getBaseUrlFromRequest(request)).toBe("https://public.steel.dev/");
+    expect(getBaseUrlFromRequest(request, "ws")).toBe("wss://public.steel.dev/");
+    expect(getUrlFromRequest(request, "v1/sessions/debug")).toBe(
+      "https://public.steel.dev/v1/sessions/debug",
+    );
+  });
+
+  it("prefers request host headers for externally visible urls", async () => {
+    vi.stubEnv("HOST", "0.0.0.0");
+    vi.stubEnv("PORT", "3000");
+    vi.stubEnv("USE_SSL", "false");
+    vi.stubEnv("DOMAIN", "");
+
+    const { getBaseUrlFromRequest, getUrlFromRequest } = await import("./url.js");
+
+    const request = {
+      headers: {
+        host: "steel.example.com",
+        "x-forwarded-proto": "https",
+      },
+    } as any;
+
+    expect(getBaseUrlFromRequest(request)).toBe("https://steel.example.com/");
+    expect(getBaseUrlFromRequest(request, "ws")).toBe("wss://steel.example.com/");
+    expect(getUrlFromRequest(request, "v1/sessions/debug")).toBe(
+      "https://steel.example.com/v1/sessions/debug",
+    );
+  });
+});

--- a/api/src/utils/url.ts
+++ b/api/src/utils/url.ts
@@ -1,3 +1,5 @@
+import type { FastifyRequest } from "fastify";
+
 import { env } from "../env.js";
 
 /**
@@ -9,14 +11,78 @@ function getProtocol(protocolType: "http" | "ws"): string {
   return env.USE_SSL ? `${protocolType}s` : protocolType;
 }
 
+function isWildcardHost(host: string): boolean {
+  return host === "0.0.0.0" || host === "::";
+}
+
+function getPublicHost(): string {
+  if (env.DOMAIN) return env.DOMAIN;
+
+  const host = env.HOST;
+  if (isWildcardHost(host)) {
+    return `localhost:${env.PORT}`;
+  }
+
+  return `${host}:${env.PORT}`;
+}
+
+export function getInternalHost(): string {
+  const host = env.HOST_IP ?? env.HOST;
+  if (isWildcardHost(host)) {
+    return "localhost";
+  }
+  return host;
+}
+
+function getRequestHost(request: FastifyRequest): string | null {
+  const forwardedHost = request.headers["x-forwarded-host"];
+  if (typeof forwardedHost === "string" && forwardedHost.trim()) {
+    return forwardedHost.trim();
+  }
+  if (Array.isArray(forwardedHost) && forwardedHost[0]?.trim()) {
+    return forwardedHost[0].trim();
+  }
+
+  const host = request.headers.host;
+  if (typeof host === "string" && host.trim()) {
+    return host.trim();
+  }
+
+  return null;
+}
+
+function getRequestProtocol(request: FastifyRequest, protocolType: "http" | "ws"): string {
+  const forwardedProto = request.headers["x-forwarded-proto"];
+  const normalized = typeof forwardedProto === "string" ? forwardedProto.split(",")[0].trim() : "";
+
+  if (normalized === "https" || normalized === "wss") {
+    return protocolType === "ws" ? "wss" : "https";
+  }
+  if (normalized === "http" || normalized === "ws") {
+    return protocolType === "ws" ? "ws" : "http";
+  }
+
+  return getProtocol(protocolType);
+}
+
 /**
  * Returns the base URL for the server, handling DOMAIN vs HOST:PORT appropriately
  * @param protocolType 'http' or 'ws' - determines the protocol prefix
- * @returns Formatted base URL with appropriate protocol and trailing slash
+ * @returns Formatted URL with appropriate protocol and trailing slash
  */
 export function getBaseUrl(protocolType: "http" | "ws" = "http"): string {
-  const baseUrl = env.DOMAIN ?? `${env.HOST}:${env.PORT}`;
+  const baseUrl = getPublicHost();
   const protocol = getProtocol(protocolType);
+  return `${protocol}://${baseUrl}/`;
+}
+
+export function getBaseUrlFromRequest(
+  request: FastifyRequest,
+  protocolType: "http" | "ws" = "http",
+): string {
+  const requestHost = getRequestHost(request);
+  const baseUrl = requestHost || getPublicHost();
+  const protocol = getRequestProtocol(request, protocolType);
   return `${protocol}://${baseUrl}/`;
 }
 
@@ -28,7 +94,16 @@ export function getBaseUrl(protocolType: "http" | "ws" = "http"): string {
  */
 export function getUrl(path: string, protocolType: "http" | "ws" = "http"): string {
   const base = getBaseUrl(protocolType);
-  // Handle paths that might already have a leading slash
+  const formattedPath = path.startsWith("/") ? path.substring(1) : path;
+  return `${base}${formattedPath}`;
+}
+
+export function getUrlFromRequest(
+  request: FastifyRequest,
+  path: string,
+  protocolType: "http" | "ws" = "http",
+): string {
+  const base = getBaseUrlFromRequest(request, protocolType);
   const formattedPath = path.startsWith("/") ? path.substring(1) : path;
   return `${base}${formattedPath}`;
 }


### PR DESCRIPTION
## Description

Fixes #222 by stopping self-hosted session URLs from using wildcard bind hosts like `0.0.0.0`.

## Type of Change

- [x] Bug fix
- [x] Test addition/update

## Related Issues

Closes #222

## Changes Made

- [x] Normalize public session/debug URLs so wildcard hosts fall back to `localhost` unless a real `DOMAIN` or forwarded host is present
- [x] Build externally visible session URLs from request host/proto headers when available
- [x] Use a non-wildcard internal host for the cast-side Puppeteer WebSocket connection
- [x] Add focused URL helper regression tests

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [x] All existing tests pass

Local verification:
- `cd api && npx vitest run src/utils/url.test.ts`
- repo pre-commit passed, including API formatting, UI lint, and full API+UI build

## Breaking Changes

None.

## Screenshots

N/A. This fixes self-hosted URL generation and cast connection targets.
