### PR TITLE
feat(sessions): add caCertificates support

### DIFF
--- a/api/src/services/cdp/utils/validation.test.ts
+++ b/api/src/services/cdp/utils/validation.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { isSimilarConfig } from "./validation.js";
+import type { BrowserLauncherOptions } from "../../../types/browser.js";
+
+// Minimal valid config — only required field is `options`
+const base: BrowserLauncherOptions = { options: {} };
+
+const withCerts = (certs: string[]): BrowserLauncherOptions => ({
+  ...base,
+  caCertificates: certs,
+});
+
+describe("isSimilarConfig", () => {
+  describe("missing configs", () => {
+    it("returns false when both configs are undefined", async () => {
+      expect(await isSimilarConfig(undefined, undefined)).toBe(false);
+    });
+
+    it("returns false when current is undefined", async () => {
+      expect(await isSimilarConfig(undefined, base)).toBe(false);
+    });
+
+    it("returns false when next is undefined", async () => {
+      expect(await isSimilarConfig(base, undefined)).toBe(false);
+    });
+  });
+
+  describe("caCertificates", () => {
+    const certA = "-----BEGIN CERTIFICATE-----\nMIIBcert-a\n-----END CERTIFICATE-----";
+    const certB = "-----BEGIN CERTIFICATE-----\nMIIBcert-b\n-----END CERTIFICATE-----";
+
+    it("treats both undefined as similar", async () => {
+      expect(await isSimilarConfig(base, base)).toBe(true);
+    });
+
+    it("treats both empty arrays as similar", async () => {
+      expect(await isSimilarConfig(withCerts([]), withCerts([]))).toBe(true);
+    });
+
+    it("treats undefined and empty array as similar", async () => {
+      expect(await isSimilarConfig(base, withCerts([]))).toBe(true);
+      expect(await isSimilarConfig(withCerts([]), base)).toBe(true);
+    });
+
+    it("treats identical cert arrays as similar", async () => {
+      expect(await isSimilarConfig(withCerts([certA]), withCerts([certA]))).toBe(true);
+    });
+
+    it("treats same certs in different order as similar", async () => {
+      expect(await isSimilarConfig(withCerts([certA, certB]), withCerts([certB, certA]))).toBe(
+        true,
+      );
+    });
+
+    it("treats different certs as not similar", async () => {
+      expect(await isSimilarConfig(withCerts([certA]), withCerts([certB]))).toBe(false);
+    });
+
+    it("treats a cert being added as not similar", async () => {
+      expect(await isSimilarConfig(base, withCerts([certA]))).toBe(false);
+      expect(await isSimilarConfig(withCerts([certA]), base)).toBe(false);
+    });
+
+    it("treats a cert being removed as not similar", async () => {
+      expect(await isSimilarConfig(withCerts([certA, certB]), withCerts([certA]))).toBe(false);
+    });
+
+    it("treats a subset of certs as not similar", async () => {
+      expect(await isSimilarConfig(withCerts([certA]), withCerts([certA, certB]))).toBe(false);
+    });
+  });
+
+  describe("existing fields are unaffected", () => {
+    it("headless mismatch is not similar", async () => {
+      const headless: BrowserLauncherOptions = { options: { headless: true } };
+      const headful: BrowserLauncherOptions = { options: { headless: false } };
+      expect(await isSimilarConfig(headless, headful)).toBe(false);
+    });
+
+    it("proxy mismatch is not similar", async () => {
+      const a: BrowserLauncherOptions = { options: { proxyUrl: "http://proxy-a:3128" } };
+      const b: BrowserLauncherOptions = { options: { proxyUrl: "http://proxy-b:3128" } };
+      expect(await isSimilarConfig(a, b)).toBe(false);
+    });
+
+    it("userAgent mismatch is not similar", async () => {
+      const a: BrowserLauncherOptions = { ...base, userAgent: "Mozilla/5.0 (agent-a)" };
+      const b: BrowserLauncherOptions = { ...base, userAgent: "Mozilla/5.0 (agent-b)" };
+      expect(await isSimilarConfig(a, b)).toBe(false);
+    });
+
+    it("matching full config with caCertificates is similar", async () => {
+      const certA = "-----BEGIN CERTIFICATE-----\nMIIBcert-a\n-----END CERTIFICATE-----";
+      const config: BrowserLauncherOptions = {
+        options: { headless: true, proxyUrl: "http://proxy:3128" },
+        userAgent: "Mozilla/5.0",
+        blockAds: true,
+        caCertificates: [certA],
+      };
+      expect(await isSimilarConfig(config, { ...config })).toBe(true);
+    });
+  });
+});

--- a/api/src/services/cdp/utils/validation.ts
+++ b/api/src/services/cdp/utils/validation.ts
@@ -184,6 +184,8 @@ export async function isSimilarConfig(
     JSON.stringify(currentExtra) === JSON.stringify(nextExtra) &&
     JSON.stringify(current.userPreferences) === JSON.stringify(next.userPreferences) &&
     JSON.stringify(current.deviceConfig) === JSON.stringify(next.deviceConfig) &&
+    JSON.stringify((current.caCertificates ?? []).slice().sort()) ===
+      JSON.stringify((next.caCertificates ?? []).slice().sort()) &&
     (await timezoneComparisonPromise)
   );
 }

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -116,6 +116,7 @@ export class SessionService {
     fullscreen?: boolean;
     headless?: boolean;
     dangerouslyLogRequestDetails?: boolean;
+    caCertificates?: string[];
   }): Promise<SessionDetails> {
     const {
       sessionId,
@@ -138,6 +139,7 @@ export class SessionService {
       headless,
       dangerouslyLogRequestDetails,
     } = options;
+    const { caCertificates } = options;
 
     // start fetching timezone as early as possible
     let timezonePromise: Promise<string>;
@@ -232,6 +234,7 @@ export class SessionService {
       deviceConfig,
       fullscreen,
       dangerouslyLogRequestDetails,
+      caCertificates,
     };
 
     if (isSelenium) {

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -138,8 +138,8 @@ export class SessionService {
       fullscreen,
       headless,
       dangerouslyLogRequestDetails,
+      caCertificates,
     } = options;
-    const { caCertificates } = options;
 
     // start fetching timezone as early as possible
     let timezonePromise: Promise<string>;

--- a/api/src/types/browser.ts
+++ b/api/src/types/browser.ts
@@ -55,6 +55,7 @@ export interface BrowserLauncherOptions {
   deviceConfig?: { device: "desktop" | "mobile" };
   fullscreen?: boolean;
   dangerouslyLogRequestDetails?: boolean;
+  caCertificates?: string[];
 }
 
 export interface BrowserServerOptions {


### PR DESCRIPTION
## Description

Add a new field to `session` called `caCertificates` which will be used to pass arbitrary CA certs to the browser session. Also add tests for CDP's validation function that were missing.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/update

## Related Issues

Closes #(issue number)
Related to #(issue number)

## Changes Made

- [ ] List specific changes made
- [ ] Include any new files or major modifications
- [ ] Mention any removed functionality

## Testing

- [ ] I have tested this locally
- [X] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested with Docker
- [X] All existing tests pass

## Documentation

- [ ] I have updated relevant documentation
- [ ] I have added JSDoc comments for new public APIs
- [ ] I have updated the README if needed
- [ ] I have updated the CHANGELOG if needed

## Code Quality

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors

## Breaking Changes

If this is a breaking change, please describe:

1. What breaks:
2. How users should migrate:
3. Why this change is necessary:

## Screenshots (if applicable)

Include screenshots or GIFs for UI changes.

## Additional Notes

Any additional information, concerns, or context for reviewers.

---

## Reviewer Checklist

- [ ] Code follows project conventions and style
- [ ] Changes are well-tested
- [ ] Documentation is updated appropriately
- [ ] No security concerns
- [ ] Performance impact is acceptable
- [ ] Breaking changes are properly documented 