### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ The simplest way to deploy/run a Steel browser instance locally is to run the pr
 
 ```bash
 # Pull and run the Docker image
+
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/steel-dev-steel-browser)
+
 docker run -p 3000:3000 -p 9223:9223 ghcr.io/steel-dev/steel-browser
 ```
 


### PR DESCRIPTION
Hi! 👋 **steel-browser** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/steel-dev-steel-browser

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building steel-browser! 🙏