### PR TITLE
fix(cdp): fall back to relaxed fingerprint constraints instead of hard-failing

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -707,8 +707,35 @@ export class CDPService extends EventEmitter {
                 };
               }
 
-              const fingerprintGen = new FingerprintGenerator(fingerprintOptions);
-              this.fingerprintData = fingerprintGen.getFingerprint();
+              // fingerprint-generator's bundled dataset lags the latest Chrome
+              // release, so a hardcoded newest-Chrome `minVersion` (and/or the
+              // tight `screen` box) can leave zero matching samples and make
+              // getFingerprint() throw deterministically. Prefer the strict
+              // options for best stealth, but relax progressively rather than
+              // hard-fail when the dataset cannot satisfy them.
+              const fallbackOptions: Array<Partial<FingerprintGeneratorOptions>> = [
+                fingerprintOptions,
+                { ...fingerprintOptions, browsers: [{ name: "chrome" }] },
+                { ...fingerprintOptions, browsers: [{ name: "chrome" }], screen: undefined },
+              ];
+              let fingerprintErr: unknown;
+              for (const options of fallbackOptions) {
+                try {
+                  this.fingerprintData = new FingerprintGenerator(options).getFingerprint();
+                  if (options !== fingerprintOptions) {
+                    this.logger.warn(
+                      { requested: fingerprintOptions, used: options },
+                      "[CDPService] Strict fingerprint constraints unsatisfiable in the bundled dataset; generated with relaxed constraints",
+                    );
+                  }
+                  break;
+                } catch (err) {
+                  fingerprintErr = err;
+                }
+              }
+              if (!this.fingerprintData) {
+                throw fingerprintErr;
+              }
             },
             (error) => {
               this.logger.error({ err: error }, "[CDPService] Error generating fingerprint");


### PR DESCRIPTION
## Problem

On `:latest` (0.5.2), **every** `POST /v1/sessions` — and the startup browser launch — fails with HTTP 500:

```
Fingerprint error during generation: Failed to generate a consistent fingerprint after 10 attempts
  at FingerprintGenerator.getFingerprint (fingerprint-generator/fingerprint-generator.js:127)
```

### Root cause

`cdp.service.ts` requests a fingerprint with:

```ts
browsers: [{ name: "chrome", minVersion: 146 }],
screen: { minWidth/maxWidth: 1920, minHeight/maxHeight: 1080 },
```

`fingerprint-generator`'s **bundled real-fingerprint dataset lags the latest Chrome release**. The pinned `fingerprint-generator@2.1.82` dataset has no `linux` + `chrome ≥ 146` sample that also satisfies the locked 1920×1080 `screen` box, so `getFingerprint()` finds no candidate, retries 10×, and throws — deterministically, on every launch.

This is **structural, not a one-off**: hardcoding the newest Chrome `minVersion` against a bundled dataset that always lags guarantees a recurring full outage on each Chrome bump (until the dataset catches up and the dep is re-pinned).

## Fix

Keep the strict options as the **preferred** path (best stealth), but **relax progressively instead of hard-failing** when the dataset can't satisfy them:

1. strict (`minVersion: 146` + screen box) — unchanged behaviour when it works,
2. drop `minVersion` (any Chrome),
3. drop the `screen` box too.

A `warn` is logged when a relaxed set is used, so the lag is visible without taking sessions down. The original error is only thrown if **all** relaxations fail (dataset truly empty).

## Repro / verification

- Repro: `steel-browser:latest` on linux → `POST /v1/sessions` → 500 (fingerprint generation).
- Verified the root cause empirically: forcing the effective `minVersion` lower in the built `cdp.service.js` makes generation succeed and `POST /v1/sessions` return 200 immediately. This PR generalizes that into a self-healing fallback so it survives future Chrome bumps without a code change.

No API/behaviour change on the happy path; only adds resilience when the strict constraints are unsatisfiable.
