### PR TITLE
fix(logs): prevent stack overflow flushing large DuckDB write buffers

### DIFF
--- a/api/src/services/cdp/instrumentation/storage/duckdb-storage.ts
+++ b/api/src/services/cdp/instrumentation/storage/duckdb-storage.ts
@@ -45,6 +45,15 @@ export interface DuckDBStorageOptions {
   writeBufferFlushInterval?: number;
 }
 
+/**
+ * Maximum number of rows inserted per INSERT statement. A single INSERT that
+ * spans the entire write buffer builds a statement with ~7 bound parameters per
+ * row; spreading hundreds of thousands of params into `db.run(sql, ...params)`
+ * overflows the V8 call stack ("Maximum call stack size exceeded"). Capping the
+ * rows per statement keeps each flush bounded regardless of buffer size.
+ */
+const WRITE_CHUNK_SIZE = 1000;
+
 export class DuckDBStorage implements LogStorage {
   private db: Database | null = null;
   private dbPath: string;
@@ -142,8 +151,11 @@ export class DuckDBStorage implements LogStorage {
     try {
       await this.writeBatchInternal(toFlush);
     } catch (err) {
-      // Put events back on failure (at the front)
-      this.writeBuffer.unshift(...toFlush);
+      // Put events back on failure (at the front). Use concat rather than
+      // `unshift(...toFlush)`: spreading a large array as call arguments throws
+      // "Maximum call stack size exceeded" once the buffer is big enough, which
+      // would mask the original failure and lose the buffered events.
+      this.writeBuffer = toFlush.concat(this.writeBuffer);
       throw err;
     } finally {
       this.isFlushing = false;
@@ -215,6 +227,19 @@ export class DuckDBStorage implements LogStorage {
   }
 
   private async writeBatchInternal(
+    events: Array<{ event: BrowserEventUnion; context: Record<string, any> }>,
+  ): Promise<void> {
+    if (!this.db || events.length === 0) return;
+
+    // Insert in fixed-size chunks so a large buffer never produces a single
+    // statement with hundreds of thousands of bound parameters (see
+    // WRITE_CHUNK_SIZE).
+    for (let i = 0; i < events.length; i += WRITE_CHUNK_SIZE) {
+      await this.writeChunk(events.slice(i, i + WRITE_CHUNK_SIZE));
+    }
+  }
+
+  private async writeChunk(
     events: Array<{ event: BrowserEventUnion; context: Record<string, any> }>,
   ): Promise<void> {
     if (!this.db || events.length === 0) return;


### PR DESCRIPTION
## Problem

`DuckDBStorage.flushWriteBuffer()` flushes the **entire** write buffer in a single `INSERT`, and on failure requeues it with `unshift(...toFlush)`. Both spread a potentially huge array as function arguments:

- the `INSERT` builds one statement with ~7 bound params per row, spread into `db.run(sql, ...params)`, and
- the failure path spreads the whole batch into `Array.prototype.unshift`.

Once the buffer grows past V8's argument limit (~100k elements), this throws `RangeError: Maximum call stack size exceeded`. That error **masks the original write failure**, and because `clear()` calls `flushWriteBuffer()` before its `DELETE`, a wedged flush can stop the table from ever draining — so the buffer/table keeps growing.

Observed in production as a steady stream of `DuckDB flush error: RangeError: Maximum call stack size exceeded`, alongside Parquet-export OOMs on the same oversized tables.

## Fix

- **Chunked inserts** — `writeBatchInternal` now inserts in fixed-size chunks (`WRITE_CHUNK_SIZE = 1000`) via a new `writeChunk` helper, instead of one statement spanning the whole buffer. Each statement is bounded regardless of buffer size.
- **Safe requeue** — on flush failure, requeue with `this.writeBuffer = toFlush.concat(this.writeBuffer)` instead of `unshift(...toFlush)`, so requeue can't overflow the stack and the original error surfaces.

No behavior change on the happy path; purely bounds the per-statement size and makes the failure path safe.

## Testing

Type-checks clean (`tsc --noEmit`, 0 errors). The fix is localized to `duckdb-storage.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)