### PR TITLE
feat: add opt-in worker network instrumentation

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -1313,6 +1313,7 @@ export class CDPService extends EventEmitter {
       this.logger,
       {
         dangerouslyLogRequestDetails: sessionConfig.dangerouslyLogRequestDetails,
+        captureWorkerNetwork: sessionConfig.captureWorkerNetwork,
       },
     );
 

--- a/api/src/services/cdp/instrumentation/network-events.ts
+++ b/api/src/services/cdp/instrumentation/network-events.ts
@@ -1,0 +1,129 @@
+import type { CDPSession, Protocol, TargetType } from "puppeteer-core";
+import { BrowserEventType } from "../../../types/index.js";
+import { BrowserLogger } from "./browser-logger.js";
+
+export interface AttachNetworkEventsOptions {
+  dangerouslyLogRequestDetails?: boolean;
+}
+
+const MAX_BODY_SIZE = 1_048_576; // 1 MB
+const TEXT_MIME_PREFIXES = ["text/", "application/json", "application/xml", "application/xhtml"];
+
+function isTextMime(mime: string | undefined): boolean {
+  if (!mime) return false;
+  const lower = mime.toLowerCase();
+  return TEXT_MIME_PREFIXES.some((p) => lower.startsWith(p));
+}
+
+/**
+ * Network request logging via CDP Network domain.
+ * The caller must enable Network on the target session before attaching this.
+ */
+export function attachNetworkEvents(
+  session: CDPSession,
+  logger: BrowserLogger,
+  pageId: string,
+  targetType: TargetType,
+  options?: AttachNetworkEventsOptions,
+): void {
+  const logBodies = options?.dangerouslyLogRequestDetails === true;
+
+  // Track request metadata by requestId for use in loadingFailed (url) and loadingFinished (mimeType)
+  const requestMeta = new Map<string, { url: string; mimeType?: string }>();
+
+  session.on("Network.requestWillBeSent", (event: Protocol.Network.RequestWillBeSentEvent) => {
+    requestMeta.set(event.requestId, { url: event.request.url });
+
+    logger.record({
+      type: BrowserEventType.Request,
+      timestamp: new Date().toISOString(),
+      pageId,
+      targetType,
+      request: {
+        method: event.request.method,
+        url: event.request.url,
+        resourceType: event.type,
+        ...(logBodies && event.request.postData ? { postData: event.request.postData } : {}),
+        ...(logBodies && event.request.headers
+          ? { headers: event.request.headers as Record<string, string> }
+          : {}),
+      },
+    });
+  });
+
+  session.on("Network.responseReceived", (event: Protocol.Network.ResponseReceivedEvent) => {
+    const meta = requestMeta.get(event.requestId);
+    if (meta) {
+      meta.mimeType = event.response.mimeType;
+    }
+
+    const responseData: {
+      status: number;
+      url: string;
+      mimeType?: string;
+      headers?: Record<string, string>;
+    } = {
+      status: event.response.status,
+      url: event.response.url,
+      mimeType: event.response.mimeType,
+    };
+
+    if (logBodies && event.response.headers) {
+      responseData.headers = event.response.headers as Record<string, string>;
+    }
+
+    logger.record({
+      type: BrowserEventType.Response,
+      timestamp: new Date().toISOString(),
+      pageId,
+      targetType,
+      response: responseData,
+    });
+  });
+
+  // Always listen for loadingFinished to clean up requestMeta entries.
+  // When dangerouslyLogRequestDetails is enabled, also capture response bodies
+  // (size-capped, text-only MIME types).
+  session.on("Network.loadingFinished", (event: Protocol.Network.LoadingFinishedEvent) => {
+    const meta = requestMeta.get(event.requestId);
+    requestMeta.delete(event.requestId);
+
+    if (!logBodies) return;
+    if (event.encodedDataLength > MAX_BODY_SIZE) return;
+    if (!isTextMime(meta?.mimeType)) return;
+
+    session
+      .send("Network.getResponseBody", { requestId: event.requestId })
+      .then((result) => {
+        if (result?.body) {
+          logger.record({
+            type: BrowserEventType.ResponseBody,
+            timestamp: new Date().toISOString(),
+            pageId,
+            targetType,
+            responseBody: {
+              requestId: event.requestId,
+              body: result.body,
+              base64Encoded: result.base64Encoded,
+            },
+          });
+        }
+      })
+      .catch(() => {
+        // Response body not available (redirects, evicted, etc.) — ignore
+      });
+  });
+
+  session.on("Network.loadingFailed", (event: Protocol.Network.LoadingFailedEvent) => {
+    const url = requestMeta.get(event.requestId)?.url;
+    requestMeta.delete(event.requestId);
+
+    logger.record({
+      type: BrowserEventType.RequestFailed,
+      timestamp: new Date().toISOString(),
+      pageId,
+      targetType,
+      error: { message: event.errorText, url },
+    });
+  });
+}

--- a/api/src/services/cdp/instrumentation/page-events.ts
+++ b/api/src/services/cdp/instrumentation/page-events.ts
@@ -1,20 +1,11 @@
 import type { Page, CDPSession, TargetType, Protocol } from "puppeteer-core";
 import { BrowserEventType } from "../../../types/index.js";
 import { BrowserLogger } from "./browser-logger.js";
+import { attachNetworkEvents } from "./network-events.js";
+import type { AttachNetworkEventsOptions } from "./network-events.js";
 import { formatLocation, serializeRemoteObject } from "./utils.js";
 
-export interface AttachPageEventsOptions {
-  dangerouslyLogRequestDetails?: boolean;
-}
-
-const MAX_BODY_SIZE = 1_048_576; // 1 MB
-const TEXT_MIME_PREFIXES = ["text/", "application/json", "application/xml", "application/xhtml"];
-
-function isTextMime(mime: string | undefined): boolean {
-  if (!mime) return false;
-  const lower = mime.toLowerCase();
-  return TEXT_MIME_PREFIXES.some((p) => lower.startsWith(p));
-}
+export interface AttachPageEventsOptions extends AttachNetworkEventsOptions {}
 
 /**
  * Attach page-level event listeners. The caller must pass an already-enabled
@@ -29,7 +20,6 @@ export async function attachPageEvents(
   options?: AttachPageEventsOptions,
 ): Promise<void> {
   const pageId = (page.target() as any)._targetId as string;
-  const logBodies = options?.dangerouslyLogRequestDetails === true;
 
   // navigation
   page.on("framenavigated", (frame) => {
@@ -52,108 +42,9 @@ export async function attachPageEvents(
     navigation: { url: page.url() },
   });
 
-  // Track request metadata by requestId for use in loadingFailed (url) and loadingFinished (mimeType)
-  const requestMeta = new Map<string, { url: string; mimeType?: string }>();
-
-  // Network request logging via CDP Network domain.
-  // This fires for ALL requests including form POST navigations, unlike
-  // Puppeteer's page.on("request") which depends on Fetch interception
-  // and can miss requests during same-tab navigations.
-  session.on("Network.requestWillBeSent", (event: Protocol.Network.RequestWillBeSentEvent) => {
-    requestMeta.set(event.requestId, { url: event.request.url });
-
-    logger.record({
-      type: BrowserEventType.Request,
-      timestamp: new Date().toISOString(),
-      pageId,
-      targetType,
-      request: {
-        method: event.request.method,
-        url: event.request.url,
-        resourceType: event.type,
-        ...(logBodies && event.request.postData ? { postData: event.request.postData } : {}),
-        ...(logBodies && event.request.headers
-          ? { headers: event.request.headers as Record<string, string> }
-          : {}),
-      },
-    });
-  });
-
-  session.on("Network.responseReceived", (event: Protocol.Network.ResponseReceivedEvent) => {
-    const meta = requestMeta.get(event.requestId);
-    if (meta) {
-      meta.mimeType = event.response.mimeType;
-    }
-
-    const responseData: {
-      status: number;
-      url: string;
-      mimeType?: string;
-      headers?: Record<string, string>;
-    } = {
-      status: event.response.status,
-      url: event.response.url,
-      mimeType: event.response.mimeType,
-    };
-
-    if (logBodies && event.response.headers) {
-      responseData.headers = event.response.headers as Record<string, string>;
-    }
-
-    logger.record({
-      type: BrowserEventType.Response,
-      timestamp: new Date().toISOString(),
-      pageId,
-      targetType,
-      response: responseData,
-    });
-  });
-
-  // Always listen for loadingFinished to clean up requestMeta entries.
-  // When dangerouslyLogRequestDetails is enabled, also capture response bodies
-  // (size-capped, text-only MIME types).
-  session.on("Network.loadingFinished", (event: Protocol.Network.LoadingFinishedEvent) => {
-    const meta = requestMeta.get(event.requestId);
-    requestMeta.delete(event.requestId);
-
-    if (!logBodies) return;
-    if (event.encodedDataLength > MAX_BODY_SIZE) return;
-    if (!isTextMime(meta?.mimeType)) return;
-
-    session
-      .send("Network.getResponseBody", { requestId: event.requestId })
-      .then((result) => {
-        if (result?.body) {
-          logger.record({
-            type: BrowserEventType.ResponseBody,
-            timestamp: new Date().toISOString(),
-            pageId,
-            targetType,
-            responseBody: {
-              requestId: event.requestId,
-              body: result.body,
-              base64Encoded: result.base64Encoded,
-            },
-          });
-        }
-      })
-      .catch(() => {
-        // Response body not available (redirects, evicted, etc.) — ignore
-      });
-  });
-
-  session.on("Network.loadingFailed", (event: Protocol.Network.LoadingFailedEvent) => {
-    const url = requestMeta.get(event.requestId)?.url;
-    requestMeta.delete(event.requestId);
-
-    logger.record({
-      type: BrowserEventType.RequestFailed,
-      timestamp: new Date().toISOString(),
-      pageId,
-      targetType,
-      error: { message: event.errorText, url },
-    });
-  });
+  // This fires for ALL page-target requests including form POST navigations,
+  // unlike Puppeteer's page.on("request") which depends on Fetch interception.
+  attachNetworkEvents(session, logger, pageId, targetType, options);
 
   session.on("Runtime.consoleAPICalled", (event: Protocol.Runtime.ConsoleAPICalledEvent) => {
     const text = event.args.map(serializeRemoteObject).join(" ");

--- a/api/src/services/cdp/instrumentation/target-manager.ts
+++ b/api/src/services/cdp/instrumentation/target-manager.ts
@@ -1,18 +1,22 @@
 import { type Target, type CDPSession, TargetType } from "puppeteer-core";
 import type { FastifyBaseLogger } from "fastify";
 
-import { attachPageEvents, AttachPageEventsOptions } from "./page-events.js";
+import { attachPageEvents } from "./page-events.js";
+import type { AttachPageEventsOptions } from "./page-events.js";
 import { attachCDPEvents } from "./cdp-events.js";
 import { attachBrowserInteractionEvents } from "./browser-interaction-events.js";
 import { attachExtensionEvents } from "./extension-events.js";
 import { attachWorkerEvents } from "./worker-events.js";
+import type { AttachWorkerEventsOptions } from "./worker-events.js";
 import { BrowserLogger } from "./browser-logger.js";
 
 const INTERNAL_EXTENSIONS = new Set<string>([
   // TODO: need secret manager, recorder, and capacha IDs
 ]);
 
-export interface TargetInstrumentationOptions extends AttachPageEventsOptions {}
+export interface TargetInstrumentationOptions extends AttachPageEventsOptions {
+  captureWorkerNetwork?: boolean;
+}
 
 export class TargetInstrumentationManager {
   private attachedSessions = new Set<string>();
@@ -72,7 +76,7 @@ export class TargetInstrumentationManager {
         if (isExtensionTarget) {
           await attachExtensionEvents(target, this.logger, INTERNAL_EXTENSIONS, this.appLogger);
         } else {
-          attachWorkerEvents(target, session, this.logger, type);
+          attachWorkerEvents(target, session, this.logger, type, this.workerEventsOptions());
         }
         break;
       }
@@ -86,7 +90,7 @@ export class TargetInstrumentationManager {
         if (isExtensionTarget) {
           await attachExtensionEvents(target, this.logger, INTERNAL_EXTENSIONS, this.appLogger);
         } else {
-          attachWorkerEvents(target, session, this.logger, type);
+          attachWorkerEvents(target, session, this.logger, type, this.workerEventsOptions());
         }
         break;
       }
@@ -162,7 +166,7 @@ export class TargetInstrumentationManager {
       case TargetType.SHARED_WORKER:
         await enable("Runtime");
         await enable("Log");
-        if (isExtension) {
+        if (isExtension || this.instrumentationOptions.captureWorkerNetwork === true) {
           await enable("Network");
         }
         break;
@@ -179,5 +183,12 @@ export class TargetInstrumentationManager {
       default:
         break;
     }
+  }
+
+  private workerEventsOptions(): AttachWorkerEventsOptions {
+    return {
+      dangerouslyLogRequestDetails: this.instrumentationOptions.dangerouslyLogRequestDetails,
+      captureNetwork: this.instrumentationOptions.captureWorkerNetwork === true,
+    };
   }
 }

--- a/api/src/services/cdp/instrumentation/worker-events.ts
+++ b/api/src/services/cdp/instrumentation/worker-events.ts
@@ -1,15 +1,26 @@
 import type { Target, Protocol, TargetType, CDPSession } from "puppeteer-core";
 import { BrowserEventType } from "../../../types/index.js";
 import { BrowserLogger } from "./browser-logger.js";
+import { attachNetworkEvents } from "./network-events.js";
+import type { AttachNetworkEventsOptions } from "./network-events.js";
 import { extractTargetId, formatLocation, serializeRemoteObject } from "./utils.js";
+
+export interface AttachWorkerEventsOptions extends AttachNetworkEventsOptions {
+  captureNetwork?: boolean;
+}
 
 export function attachWorkerEvents(
   target: Target,
   session: CDPSession,
   logger: BrowserLogger,
   targetType: TargetType,
+  options?: AttachWorkerEventsOptions,
 ): void {
   const targetId = extractTargetId(target);
+
+  if (options?.captureNetwork === true) {
+    attachNetworkEvents(session, logger, targetId, targetType, options);
+  }
 
   session.on("Runtime.consoleAPICalled", (event: Protocol.Runtime.ConsoleAPICalledEvent) => {
     const text = event.args.map(serializeRemoteObject).join(" ");

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -116,6 +116,7 @@ export class SessionService {
     fullscreen?: boolean;
     headless?: boolean;
     dangerouslyLogRequestDetails?: boolean;
+    captureWorkerNetwork?: boolean;
     caCertificates?: string[];
   }): Promise<SessionDetails> {
     const {
@@ -138,6 +139,7 @@ export class SessionService {
       fullscreen,
       headless,
       dangerouslyLogRequestDetails,
+      captureWorkerNetwork,
       caCertificates,
     } = options;
 
@@ -234,6 +236,7 @@ export class SessionService {
       deviceConfig,
       fullscreen,
       dangerouslyLogRequestDetails,
+      captureWorkerNetwork,
       caCertificates,
     };
 

--- a/api/src/types/browser.ts
+++ b/api/src/types/browser.ts
@@ -55,6 +55,7 @@ export interface BrowserLauncherOptions {
   deviceConfig?: { device: "desktop" | "mobile" };
   fullscreen?: boolean;
   dangerouslyLogRequestDetails?: boolean;
+  captureWorkerNetwork?: boolean;
   caCertificates?: string[];
 }
 


### PR DESCRIPTION
This adds `captureWorkerNetwork` to steel-browser launch options and wires it into target instrumentation.

Today page and background-page targets enable `Network`, but non-extension `service_worker` and `shared_worker` targets only enable `Runtime` and `Log`. As a result, fetch/XHR initiated inside site workers is not recorded in browser logs.

Changes in this PR:

- Adds `BrowserLauncherOptions.captureWorkerNetwork`.
- Passes the option from `SessionService` into `CDPService`.
- Adds shared `attachNetworkEvents(...)` helper extracted from page network logging.
- Keeps page network logging behavior unchanged by reusing the helper from `attachPageEvents`.
- When `captureWorkerNetwork` is true, enables `Network` for non-extension service/shared workers.
- Records worker network events through existing log types: `Request`, `Response`, `RequestFailed`, and optional `ResponseBody`.

Default behavior is unchanged unless `captureWorkerNetwork` is enabled by the caller.