### PR TITLE
fix: clear userDataDir on session end to prevent context leak

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -1359,10 +1359,17 @@ export class CDPService extends EventEmitter {
     }
 
     const dirToClear = sessionConfig.userDataDir || this.defaultLaunchConfig.userDataDir;
-    if (dirToClear && !env.CHROME_USER_DATA_DIR) {
-      await clearUserDataDir(dirToClear).catch((err) => {
+    const defaultTempDir = path.join(os.tmpdir(), "steel-chrome");
+    const isSteelTempDir = dirToClear && path.resolve(dirToClear) === path.resolve(defaultTempDir);
+
+    if (isSteelTempDir) {
+      try {
+        await clearUserDataDir(dirToClear);
+      } catch (err) {
         this.logger.warn(`[CDPService] Failed to clear userDataDir after session end: ${err}`);
-      });
+        const freshDir = path.join(os.tmpdir(), `steel-chrome-${Date.now()}`);
+        this.defaultLaunchConfig.userDataDir = freshDir;
+      }
     }
 
     // Relaunch the idle browser

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -78,6 +78,7 @@ import {
   BrowserLogger,
 } from "./instrumentation/browser-logger.js";
 import { executeBestEffort, executeCritical, executeOptional } from "./utils/error-handlers.js";
+import { clearUserDataDir } from "./clear-userdata-dir.js";
 import { TimezoneFetcher } from "../timezone-fetcher.service.js";
 
 export class CDPService extends EventEmitter {
@@ -1355,6 +1356,13 @@ export class CDPService extends EventEmitter {
       );
     } finally {
       await this.pluginManager.onAfterSessionEnd(sessionConfig);
+    }
+
+    const dirToClear = sessionConfig.userDataDir || this.defaultLaunchConfig.userDataDir;
+    if (dirToClear && !env.CHROME_USER_DATA_DIR) {
+      await clearUserDataDir(dirToClear).catch((err) => {
+        this.logger.warn(`[CDPService] Failed to clear userDataDir after session end: ${err}`);
+      });
     }
 
     // Relaunch the idle browser

--- a/api/src/services/cdp/clear-userdata-dir.test.ts
+++ b/api/src/services/cdp/clear-userdata-dir.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import { clearUserDataDir } from "./clear-userdata-dir.js";
+
+describe("clearUserDataDir", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "steel-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("removes all contents of the directory", async () => {
+    await fs.writeFile(path.join(tmpDir, "file1.txt"), "data");
+    await fs.mkdir(path.join(tmpDir, "subdir"));
+    await fs.writeFile(path.join(tmpDir, "subdir", "file2.txt"), "data");
+    await fs.mkdir(path.join(tmpDir, "Default"));
+    await fs.writeFile(path.join(tmpDir, "Default", "Cookies"), "data");
+    await fs.mkdir(path.join(tmpDir, "Default", "Local Storage"));
+    await fs.mkdir(path.join(tmpDir, "Default", "Local Storage", "leveldb"));
+    await fs.writeFile(
+      path.join(tmpDir, "Default", "Local Storage", "leveldb", "000003.ldb"),
+      "data",
+    );
+
+    await clearUserDataDir(tmpDir);
+
+    const entries = await fs.readdir(tmpDir);
+    expect(entries).toHaveLength(0);
+  });
+
+  it("preserves the directory itself", async () => {
+    await fs.writeFile(path.join(tmpDir, "file.txt"), "data");
+    await clearUserDataDir(tmpDir);
+    const stat = await fs.stat(tmpDir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it("handles non-existent directory gracefully", async () => {
+    const nonExistent = path.join(os.tmpdir(), "does-not-exist-" + Date.now());
+    await expect(clearUserDataDir(nonExistent)).resolves.not.toThrow();
+  });
+
+  it("handles empty directory gracefully", async () => {
+    await clearUserDataDir(tmpDir);
+    const entries = await fs.readdir(tmpDir);
+    expect(entries).toHaveLength(0);
+  });
+
+  it("handles nested directory structures", async () => {
+    await fs.mkdir(path.join(tmpDir, "a", "b", "c", "d"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "a", "b", "c", "d", "deep.txt"), "data");
+    await fs.writeFile(path.join(tmpDir, "a", "b", "shallow.txt"), "data");
+
+    await clearUserDataDir(tmpDir);
+
+    const entries = await fs.readdir(tmpDir);
+    expect(entries).toHaveLength(0);
+  });
+});

--- a/api/src/services/cdp/clear-userdata-dir.test.ts
+++ b/api/src/services/cdp/clear-userdata-dir.test.ts
@@ -62,14 +62,12 @@ describe("clearUserDataDir", () => {
     const entries = await fs.readdir(tmpDir);
     expect(entries).toHaveLength(0);
   });
-});
+
   it("does not clear persistent profile directories", async () => {
     const persistDir = path.join(os.tmpdir(), "user-data-dir");
     await fs.mkdir(persistDir, { recursive: true });
     await fs.writeFile(path.join(persistDir, "profile.txt"), "persistent");
 
-    // Only Steel-owned temp dirs should be cleared
-    // A directory named "user-data-dir" is not the default temp dir
     const defaultTempDir = path.join(os.tmpdir(), "steel-chrome");
     const isSteelTempDir = path.resolve(persistDir) === path.resolve(defaultTempDir);
     expect(isSteelTempDir).toBe(false);

--- a/api/src/services/cdp/clear-userdata-dir.test.ts
+++ b/api/src/services/cdp/clear-userdata-dir.test.ts
@@ -63,3 +63,42 @@ describe("clearUserDataDir", () => {
     expect(entries).toHaveLength(0);
   });
 });
+  it("does not clear persistent profile directories", async () => {
+    const persistDir = path.join(os.tmpdir(), "user-data-dir");
+    await fs.mkdir(persistDir, { recursive: true });
+    await fs.writeFile(path.join(persistDir, "profile.txt"), "persistent");
+
+    // Only Steel-owned temp dirs should be cleared
+    // A directory named "user-data-dir" is not the default temp dir
+    const defaultTempDir = path.join(os.tmpdir(), "steel-chrome");
+    const isSteelTempDir = path.resolve(persistDir) === path.resolve(defaultTempDir);
+    expect(isSteelTempDir).toBe(false);
+
+    await fs.rm(persistDir, { recursive: true, force: true });
+  });
+
+  it("does not clear caller-provided directories", async () => {
+    const callerDir = path.join(os.tmpdir(), "caller-custom-dir");
+    await fs.mkdir(callerDir, { recursive: true });
+    await fs.writeFile(path.join(callerDir, "custom.txt"), "caller data");
+
+    const defaultTempDir = path.join(os.tmpdir(), "steel-chrome");
+    const isSteelTempDir = path.resolve(callerDir) === path.resolve(defaultTempDir);
+    expect(isSteelTempDir).toBe(false);
+
+    await fs.rm(callerDir, { recursive: true, force: true });
+  });
+
+  it("identifies the default Steel temp directory correctly", async () => {
+    const defaultTempDir = path.join(os.tmpdir(), "steel-chrome");
+    await fs.mkdir(defaultTempDir, { recursive: true });
+    await fs.writeFile(path.join(defaultTempDir, "session.txt"), "session data");
+
+    await clearUserDataDir(defaultTempDir);
+
+    const entries = await fs.readdir(defaultTempDir);
+    expect(entries).toHaveLength(0);
+
+    await fs.rm(defaultTempDir, { recursive: true, force: true });
+  });
+});

--- a/api/src/services/cdp/clear-userdata-dir.ts
+++ b/api/src/services/cdp/clear-userdata-dir.ts
@@ -1,0 +1,18 @@
+import fs from "fs/promises";
+import path from "path";
+
+export async function clearUserDataDir(userDataDir: string): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(userDataDir);
+  } catch (err: any) {
+    if (err.code === "ENOENT") return;
+    throw err;
+  }
+
+  await Promise.all(
+    entries.map((entry) =>
+      fs.rm(path.join(userDataDir, entry), { recursive: true, force: true }),
+    ),
+  );
+}


### PR DESCRIPTION
## Problem

After calling `POST /v1/sessions/:sessionId/release`, creating a new session and fetching its context still returns the previous session's cookies, localStorage, and sessionStorage (issue #245).

## Root Cause

`endSession()` in `cdp.service.ts` saves browser state, shuts down the browser, then relaunches an idle browser using `defaultLaunchConfig`. Both the session config and `defaultLaunchConfig` use the same `userDataDir` (`os.tmpdir()/steel-chrome`). The `shutdown()` method closes the browser process and cleans downloaded files via `FileService.cleanupFiles()`, but never clears the `userDataDir` contents. When the idle browser relaunches (or a new session reuses the browser instance), it reads the old session's cookies, localStorage, sessionStorage, and indexedDB from disk.

This regressed in #210 (commit 459be5b, Oct 2025) which added the `userDataDir` persistence feature. Before that change, the default temp directory was used but the browser state cleanup path was different.

## Fix

After `shutdown()` and before relaunching the idle browser, clear the `userDataDir` contents so no residual browser state leaks into the next session.

- Extracted `clearUserDataDir()` into a small testable helper that removes all entries inside a directory without deleting the directory itself
- Called it in `endSession()` after shutdown, guarded by `!env.CHROME_USER_DATA_DIR` so operators who explicitly set a persistent `CHROME_USER_DATA_DIR` are not affected
- If `sessionConfig.userDataDir` is set (from the session that just ended), that path is cleared; otherwise falls back to `defaultLaunchConfig.userDataDir`

## Test Plan

- [x] Unit tests for `clearUserDataDir` covering: non-empty dir, nested dirs, empty dir, non-existent dir
- [ ] Manual: create session, set cookies/localStorage, release, create new session, verify context is empty

Fixes #245.