### PR TITLE
fix(cdp): capture network requests from dedicated web workers

### DIFF
--- a/api/src/services/cdp/instrumentation/target-manager.test.ts
+++ b/api/src/services/cdp/instrumentation/target-manager.test.ts
@@ -1,0 +1,61 @@
+import { EventEmitter } from "node:events";
+import type { CDPSession, Target } from "puppeteer-core";
+import { TargetType } from "puppeteer-core";
+import { describe, expect, it, vi } from "vitest";
+
+import { BrowserEventType } from "../../../types/index.js";
+import { TargetInstrumentationManager } from "./target-manager.js";
+
+describe("TargetInstrumentationManager", () => {
+  it("captures network requests from dedicated worker targets", async () => {
+    const session = new EventEmitter() as EventEmitter & {
+      send: ReturnType<typeof vi.fn>;
+      id: () => string;
+    };
+    const send = vi.fn().mockResolvedValue({});
+    session.send = send;
+    session.id = () => "cdp-session";
+
+    const target = {
+      _targetId: "worker-target",
+      _getTargetInfo: () => ({ type: "worker" }),
+      url: () => "blob:https://example.com/worker",
+      createCDPSession: vi.fn().mockResolvedValue(session as unknown as CDPSession),
+    } as unknown as Target;
+    const logger = {
+      record: vi.fn(),
+      resetContext: vi.fn(),
+      setContext: vi.fn(),
+      getContext: vi.fn().mockReturnValue({}),
+    };
+    const manager = new TargetInstrumentationManager(logger, { error: vi.fn() } as any, {
+      captureWorkerNetwork: true,
+    });
+
+    await manager.attach(target, TargetType.OTHER);
+
+    expect(send).toHaveBeenCalledWith("Network.enable");
+
+    session.emit("Network.requestWillBeSent", {
+      requestId: "request-1",
+      request: {
+        method: "POST",
+        url: "https://example.com/worker-request",
+        headers: {},
+      },
+      type: "Fetch",
+    });
+
+    expect(logger.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: BrowserEventType.Request,
+        pageId: "worker-target",
+        targetType: TargetType.OTHER,
+        request: expect.objectContaining({
+          method: "POST",
+          url: "https://example.com/worker-request",
+        }),
+      }),
+    );
+  });
+});

--- a/api/src/services/cdp/instrumentation/target-manager.ts
+++ b/api/src/services/cdp/instrumentation/target-manager.ts
@@ -35,6 +35,8 @@ export class TargetInstrumentationManager {
   async attach(target: Target, type: TargetType) {
     const url = target.url?.() ?? "";
     const isExtensionTarget = url.startsWith("chrome-extension://");
+    const isDedicatedWorker =
+      type === TargetType.OTHER && (target as any)._getTargetInfo?.().type === "worker";
     const sessionId = (target as any)._targetId;
 
     if (this.attachedSessions.has(sessionId)) {
@@ -109,8 +111,21 @@ export class TargetInstrumentationManager {
         break;
       }
 
+      case TargetType.OTHER: {
+        const session = await target.createCDPSession();
+        this.cdpSessions.set(sessionId, session);
+        await this.enableDomainsForTarget(session, type, isExtensionTarget, isDedicatedWorker);
+        attachCDPEvents(session, this.logger);
+
+        if (isExtensionTarget) {
+          await attachExtensionEvents(target, this.logger, INTERNAL_EXTENSIONS, this.appLogger);
+        } else if (isDedicatedWorker) {
+          attachWorkerEvents(target, session, this.logger, type, this.workerEventsOptions());
+        }
+        break;
+      }
+
       case TargetType.BROWSER:
-      case TargetType.OTHER:
       default: {
         const session = await target.createCDPSession();
         this.cdpSessions.set(sessionId, session);
@@ -140,6 +155,7 @@ export class TargetInstrumentationManager {
     session: CDPSession,
     type: TargetType,
     isExtension: boolean,
+    isDedicatedWorker = false,
   ): Promise<void> {
     const enabledDomains = new Set<string>();
 
@@ -173,10 +189,12 @@ export class TargetInstrumentationManager {
 
       case TargetType.WEBVIEW:
       case TargetType.OTHER:
-        if (isExtension) {
+        if (isExtension || isDedicatedWorker) {
           await enable("Runtime");
           await enable("Log");
-          await enable("Network");
+          if (isExtension || this.instrumentationOptions.captureWorkerNetwork === true) {
+            await enable("Network");
+          }
         }
         break;
 


### PR DESCRIPTION
## Description

Fixes network request capture for dedicated web workers when `captureWorkerNetwork` is enabled.

Puppeteer maps Chromium’s dedicated `worker` targets to `TargetType.OTHER`, so they were previously excluded from worker network instrumentation. This affected sites such as Wix that send requests from dedicated workers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/update

## Related Issues

N/A

## Changes Made

- [x] Detect dedicated web workers reported by Puppeteer as `TargetType.OTHER`
- [x] Enable the Runtime, Log, and Network CDP domains for dedicated workers when worker network capture is enabled
- [x] Attach existing worker event instrumentation to dedicated worker targets
- [x] Add unit coverage verifying dedicated worker requests are recorded
- [x] Preserve existing behavior for unrelated `TargetType.OTHER` targets

## Testing

- [x] I have tested this locally
- [x] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested with Docker
- [x] All existing tests pass

Validated with:

- Full API test suite: 72 passed, 2 skipped
- TypeScript build
- Prettier formatting check
- Local Chromium reproduction using a request initiated from a dedicated web worker

## Documentation

- [ ] I have updated relevant documentation
- [ ] I have added JSDoc comments for new public APIs
- [ ] I have updated the README if needed
- [ ] I have updated the CHANGELOG if needed

No documentation changes are required because this fixes existing opt-in behavior and does not introduce a new public API.

## Code Quality

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

## Breaking Changes

None.

## Screenshots (if applicable)

N/A

## Additional Notes

This is a follow-up to the existing worker network capture implementation. The previous implementation handled service workers and shared workers but did not account for dedicated workers being represented as `TargetType.OTHER` by Puppeteer.

---

## Reviewer Checklist

- [ ] Code follows project conventions and style
- [ ] Changes are well-tested
- [ ] Documentation is updated appropriately
- [ ] No security concerns
- [ ] Performance impact is acceptable
- [ ] Breaking changes are properly documented