### PR TITLE
fix(api): contain target setup work during browser shutdown

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -79,6 +79,9 @@ import {
 } from "./instrumentation/browser-logger.js";
 import { executeBestEffort, executeCritical, executeOptional } from "./utils/error-handlers.js";
 import { TimezoneFetcher } from "../timezone-fetcher.service.js";
+import { TargetTaskTracker } from "./target-task-tracker.js";
+
+const TARGET_TASK_DRAIN_TIMEOUT_MS = 1_000;
 
 export class CDPService extends EventEmitter {
   private logger: FastifyBaseLogger;
@@ -102,6 +105,7 @@ export class CDPService extends EventEmitter {
   private retryManager: RetryManager;
   private targetInstrumentationManager: TargetInstrumentationManager;
   private instrumentationLogger: BrowserLogger;
+  private targetTasks: TargetTaskTracker;
 
   private compiledUrlPatterns: RegExp[] = [];
   private launchMutators: ((config: BrowserLauncherOptions) => Promise<void> | void)[] = [];
@@ -178,6 +182,17 @@ export class CDPService extends EventEmitter {
       this.instrumentationLogger,
       this.logger,
     );
+    this.targetTasks = new TargetTaskTracker({
+      onError: (error) => {
+        this.logger.error({ err: error }, "[CDPService] Target setup task failed");
+      },
+      onTimeout: (pendingTasks) => {
+        this.logger.warn(
+          { pendingTasks },
+          "[CDPService] Timed out draining target setup tasks before browser shutdown",
+        );
+      },
+    });
     this.instrumentationLogger?.on?.(EmitEvent.Log, (event, context) => {
       this.emit(EmitEvent.Log, event);
     });
@@ -287,7 +302,11 @@ export class CDPService extends EventEmitter {
     return this.pluginManager.unregister(pluginName);
   }
 
-  private async handleTargetChange(target: Target) {
+  private async handleTargetChange(
+    target: Target,
+    isActive: () => boolean = () => !this.shuttingDown,
+  ) {
+    if (!isActive()) return;
     if (target.type() !== "page") return;
 
     const page = await target.page().catch((e) => {
@@ -295,8 +314,9 @@ export class CDPService extends EventEmitter {
       return null;
     });
 
-    if (page) {
-      this.pluginManager.onPageNavigate(page);
+    if (page && isActive()) {
+      await this.pluginManager.onPageNavigate(page);
+      if (!isActive()) return;
 
       //@ts-ignore
       const pageId = page.target()._targetId;
@@ -317,12 +337,18 @@ export class CDPService extends EventEmitter {
     }
   }
 
-  private async handleNewTarget(target: Target) {
+  private async handleNewTarget(
+    target: Target,
+    isActive: () => boolean = () => !this.shuttingDown,
+  ) {
+    if (!isActive()) return;
     try {
       await this.targetInstrumentationManager.attach(target, target.type() as TargetType);
     } catch (error) {
       this.logger.error({ err: error }, `[CDPService] Error attaching target instrumentation`);
     }
+
+    if (!isActive()) return;
 
     if (target.type() === TargetType.PAGE) {
       const page = await target.page().catch((e) => {
@@ -331,6 +357,7 @@ export class CDPService extends EventEmitter {
       });
 
       if (page) {
+        if (!isActive()) return;
         try {
           const url = page.url();
           if (url && url.startsWith("http")) {
@@ -344,11 +371,14 @@ export class CDPService extends EventEmitter {
 
         // Notify plugins about the new page
         await this.pluginManager.onPageCreated(page);
+        if (!isActive()) return;
 
         // Only install mouse helper in headless mode
         if (this.launchConfig?.options?.headless) {
-          installMouseHelper(page, this.launchConfig?.deviceConfig?.device || "desktop");
+          await installMouseHelper(page, this.launchConfig?.deviceConfig?.device || "desktop");
         }
+
+        if (!isActive()) return;
 
         if (this.launchConfig?.customHeaders) {
           await page.setExtraHTTPHeaders({
@@ -358,8 +388,10 @@ export class CDPService extends EventEmitter {
         } else if (env.DEFAULT_HEADERS) {
           await page.setExtraHTTPHeaders(env.DEFAULT_HEADERS);
         }
+        if (!isActive()) return;
 
         await this.applyDeviceMetricsOverride(page);
+        if (!isActive()) return;
 
         // Inject fingerprint only if it's not skipped
         if (!env.SKIP_FINGERPRINT_INJECTION && !this.launchConfig?.skipFingerprintInjection) {
@@ -371,8 +403,10 @@ export class CDPService extends EventEmitter {
             "[CDPService] Fingerprint injection skipped due to 'SKIP_FINGERPRINT_INJECTION' setting",
           );
         }
+        if (!isActive()) return;
 
         await page.setRequestInterception(true);
+        if (!isActive()) return;
 
         page.on("request", (request) => this.handlePageRequest(request, page));
 
@@ -465,6 +499,8 @@ export class CDPService extends EventEmitter {
     this.logger.info(`[CDPService] Shutting down and cleaning up resources (reason: ${reason})`);
 
     try {
+      await this.targetTasks.stop(TARGET_TASK_DRAIN_TIMEOUT_MS);
+
       if (this.browserInstance) {
         await this.pluginManager.onBrowserClose(this.browserInstance);
       }
@@ -1017,8 +1053,17 @@ export class CDPService extends EventEmitter {
           "Failed to configure download behavior",
         );
 
-        this.browserInstance.on("targetcreated", this.handleNewTarget.bind(this));
-        this.browserInstance.on("targetchanged", this.handleTargetChange.bind(this));
+        this.targetTasks.resume();
+        this.browserInstance.on("targetcreated", (target) => {
+          this.targetTasks.schedule(
+            async (isActive) => await this.handleNewTarget(target, isActive),
+          );
+        });
+        this.browserInstance.on("targetchanged", (target) => {
+          this.targetTasks.schedule(
+            async (isActive) => await this.handleTargetChange(target, isActive),
+          );
+        });
         this.browserInstance.on("targetdestroyed", (target) => {
           const targetId = (target as any)._targetId;
           this.targetInstrumentationManager.detach(targetId);

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -337,13 +337,25 @@ export class CDPService extends EventEmitter {
     }
   }
 
+  private createTargetInstrumentationManager(): TargetInstrumentationManager {
+    return new TargetInstrumentationManager(
+      this.instrumentationLogger,
+      this.logger,
+      {
+        dangerouslyLogRequestDetails: this.launchConfig?.dangerouslyLogRequestDetails,
+        captureWorkerNetwork: this.launchConfig?.captureWorkerNetwork,
+      },
+    );
+  }
+
   private async handleNewTarget(
     target: Target,
     isActive: () => boolean = () => !this.shuttingDown,
+    instrumentationManager: TargetInstrumentationManager = this.targetInstrumentationManager,
   ) {
     if (!isActive()) return;
     try {
-      await this.targetInstrumentationManager.attach(target, target.type() as TargetType);
+      await instrumentationManager.attach(target, target.type() as TargetType);
     } catch (error) {
       this.logger.error({ err: error }, `[CDPService] Error attaching target instrumentation`);
     }
@@ -1053,10 +1065,12 @@ export class CDPService extends EventEmitter {
           "Failed to configure download behavior",
         );
 
+        const instrumentationManager = this.createTargetInstrumentationManager();
+        this.targetInstrumentationManager = instrumentationManager;
         this.targetTasks.resume();
         this.browserInstance.on("targetcreated", (target) => {
           this.targetTasks.schedule(
-            async (isActive) => await this.handleNewTarget(target, isActive),
+            async (isActive) => await this.handleNewTarget(target, isActive, instrumentationManager),
           );
         });
         this.browserInstance.on("targetchanged", (target) => {
@@ -1066,7 +1080,7 @@ export class CDPService extends EventEmitter {
         });
         this.browserInstance.on("targetdestroyed", (target) => {
           const targetId = (target as any)._targetId;
-          this.targetInstrumentationManager.detach(targetId);
+          instrumentationManager.detach(targetId);
         });
         this.browserInstance.on("disconnected", this.onDisconnect.bind(this));
 
@@ -1084,7 +1098,7 @@ export class CDPService extends EventEmitter {
         await executeOptional(
           this.logger,
           async () => {
-            await this.handleNewTarget(this.primaryPage!.target());
+            await this.handleNewTarget(this.primaryPage!.target(), () => !this.shuttingDown, instrumentationManager);
             await this.handleTargetChange(this.primaryPage!.target());
           },
           (error) =>
@@ -1099,7 +1113,7 @@ export class CDPService extends EventEmitter {
           const existingTargets = await this.browserInstance.targets();
           for (const target of existingTargets) {
             if ((target as any)._targetId !== (this.primaryPage.target() as any)._targetId) {
-              await this.targetInstrumentationManager.attach(target, target.type() as TargetType);
+              await instrumentationManager.attach(target, target.type() as TargetType);
             }
           }
           this.logger.info(

--- a/api/src/services/cdp/target-task-tracker.test.ts
+++ b/api/src/services/cdp/target-task-tracker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { TargetTaskTracker } from "./target-task-tracker.js";
+import { TargetTaskTracker, isTargetCloseError } from "./target-task-tracker.js";
 
 function deferred<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -109,5 +109,41 @@ describe("TargetTaskTracker", () => {
       process.off("unhandledRejection", onUnhandled);
       vi.useRealTimers();
     }
+  });
+
+  it("drops timed-out records while retaining late rejection handling", async () => {
+    vi.useFakeTimers();
+    const onError = vi.fn();
+    const pending = deferred();
+    const tracker = new TargetTaskTracker({ onError });
+    const unhandled: unknown[] = [];
+    const onUnhandled = (error: unknown) => unhandled.push(error);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      tracker.schedule(() => pending.promise);
+      const stopping = tracker.stop(25);
+      await vi.advanceTimersByTimeAsync(25);
+      await expect(stopping).resolves.toBe(false);
+      expect(tracker.size).toBe(0);
+
+      pending.reject(new Error("Protocol error (Fetch.enable): Target closed"));
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+      expect(onError).not.toHaveBeenCalled();
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    [Object.assign(new Error("Protocol error (Page.addScriptToEvaluateOnNewDocument): Target closed"), { name: "TargetCloseError" }), true],
+    [new Error("Protocol error (Fetch.enable): Session closed. Most likely the page has been closed."), true],
+    [new Error("customer session closed by policy"), false],
+    [new Error("Target closed accounting invariant failed"), false],
+  ])("classifies target-close errors narrowly: %#", (error, expected) => {
+    expect(isTargetCloseError(error)).toBe(expected);
   });
 });

--- a/api/src/services/cdp/target-task-tracker.test.ts
+++ b/api/src/services/cdp/target-task-tracker.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { TargetTaskTracker } from "./target-task-tracker.js";
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("TargetTaskTracker", () => {
+  it("drains an accepted target task and contains Target closed during shutdown", async () => {
+    const errors: unknown[] = [];
+    const pending = deferred();
+    const tracker = new TargetTaskTracker({
+      onError: (error) => errors.push(error),
+    });
+
+    expect(tracker.schedule(() => pending.promise)).toBe(true);
+    const stopping = tracker.stop(100);
+    pending.reject(new Error("Protocol error (Page.addScriptToEvaluateOnNewDocument): Target closed"));
+
+    await expect(stopping).resolves.toBe(true);
+    expect(errors).toEqual([]);
+    expect(tracker.size).toBe(0);
+  });
+
+  it("rejects new target work once shutdown begins", async () => {
+    const task = vi.fn(async () => undefined);
+    const tracker = new TargetTaskTracker({ onError: vi.fn() });
+
+    await expect(tracker.stop(100)).resolves.toBe(true);
+
+    expect(tracker.schedule(task)).toBe(false);
+    expect(task).not.toHaveBeenCalled();
+  });
+
+  it("reports unrelated target errors even when shutdown is active", async () => {
+    const onError = vi.fn();
+    const pending = deferred();
+    const tracker = new TargetTaskTracker({ onError });
+
+    tracker.schedule(() => pending.promise);
+    const stopping = tracker.stop(100);
+    const failure = new Error("instrumentation invariant failed");
+    pending.reject(failure);
+
+    await expect(stopping).resolves.toBe(true);
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+
+  it("keeps timed-out work cancelled after a new generation resumes", async () => {
+    vi.useFakeTimers();
+    const entered = deferred();
+    const release = deferred();
+    let activeAfterResume: boolean | undefined;
+    const tracker = new TargetTaskTracker({ onError: vi.fn() });
+
+    try {
+      tracker.schedule(async (isActive) => {
+        entered.resolve();
+        await release.promise;
+        activeAfterResume = isActive();
+      });
+      await entered.promise;
+
+      const stopping = tracker.stop(25);
+      await vi.advanceTimersByTimeAsync(25);
+      await expect(stopping).resolves.toBe(false);
+      tracker.resume();
+      release.resolve();
+      await vi.runAllTimersAsync();
+
+      expect(activeAfterResume).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds shutdown while retaining rejection handling for a late target close", async () => {
+    vi.useFakeTimers();
+    const onError = vi.fn();
+    const onTimeout = vi.fn();
+    const pending = deferred();
+    const tracker = new TargetTaskTracker({ onError, onTimeout });
+    const unhandled: unknown[] = [];
+    const onUnhandled = (error: unknown) => unhandled.push(error);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      tracker.schedule(() => pending.promise);
+      const stopping = tracker.stop(50);
+      await vi.advanceTimersByTimeAsync(50);
+      await expect(stopping).resolves.toBe(false);
+      expect(onTimeout).toHaveBeenCalledWith(1);
+
+      tracker.resume();
+      pending.reject(new Error("Protocol error (Fetch.enable): Target closed"));
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      vi.useRealTimers();
+    }
+  });
+});

--- a/api/src/services/cdp/target-task-tracker.ts
+++ b/api/src/services/cdp/target-task-tracker.ts
@@ -8,16 +8,11 @@ export interface TargetTaskTrackerOptions {
   onTimeout?: (pendingTasks: number) => void;
 }
 
-function targetCloseMessage(error: unknown): string {
-  if (!(error instanceof Error)) return "";
-  const cause = "cause" in error ? targetCloseMessage(error.cause) : "";
-  return `${error.name}: ${error.message}\n${cause}`;
-}
-
 export function isTargetCloseError(error: unknown): boolean {
-  return /(?:TargetCloseError|Protocol error[^\n]*(?:Target|Session) closed|(?:Target|Session) closed)/i.test(
-    targetCloseMessage(error),
-  );
+  if (!(error instanceof Error)) return false;
+  if (error.name === "TargetCloseError") return true;
+  if (/^Protocol error \([^\r\n()]+\): (?:Target|Session) closed(?:\.|$)/i.test(error.message)) return true;
+  return "cause" in error && isTargetCloseError(error.cause);
 }
 
 export class TargetTaskTracker {
@@ -72,8 +67,9 @@ export class TargetTaskTracker {
     const completed = await Promise.race([drained, timedOut]);
     if (timer) clearTimeout(timer);
     if (!completed) {
+      for (const record of pending) this.tasks.delete(record);
       try {
-        this.options.onTimeout?.(this.tasks.size);
+        this.options.onTimeout?.(pending.length);
       } catch {
         // Timeout reporting is best effort and must not break shutdown.
       }

--- a/api/src/services/cdp/target-task-tracker.ts
+++ b/api/src/services/cdp/target-task-tracker.ts
@@ -1,0 +1,87 @@
+interface TargetTaskRecord {
+  promise: Promise<void>;
+  suppressTargetClose: boolean;
+}
+
+export interface TargetTaskTrackerOptions {
+  onError: (error: unknown) => void;
+  onTimeout?: (pendingTasks: number) => void;
+}
+
+function targetCloseMessage(error: unknown): string {
+  if (!(error instanceof Error)) return "";
+  const cause = "cause" in error ? targetCloseMessage(error.cause) : "";
+  return `${error.name}: ${error.message}\n${cause}`;
+}
+
+export function isTargetCloseError(error: unknown): boolean {
+  return /(?:TargetCloseError|Protocol error[^\n]*(?:Target|Session) closed|(?:Target|Session) closed)/i.test(
+    targetCloseMessage(error),
+  );
+}
+
+export class TargetTaskTracker {
+  private readonly tasks = new Set<TargetTaskRecord>();
+  private accepting = true;
+  private generation = 0;
+
+  constructor(private readonly options: TargetTaskTrackerOptions) {}
+
+  get size(): number {
+    return this.tasks.size;
+  }
+
+  schedule(task: (isActive: () => boolean) => Promise<void>): boolean {
+    if (!this.accepting) return false;
+
+    const generation = this.generation;
+    const record: TargetTaskRecord = {
+      promise: Promise.resolve(),
+      suppressTargetClose: false,
+    };
+    const isActive = () => this.accepting && this.generation === generation;
+    record.promise = Promise.resolve()
+      .then(async () => await task(isActive))
+      .catch((error) => {
+        if (record.suppressTargetClose && isTargetCloseError(error)) return;
+        try {
+          this.options.onError(error);
+        } catch {
+          // Error reporting must never turn a contained target task into an unhandled rejection.
+        }
+      })
+      .finally(() => {
+        this.tasks.delete(record);
+      });
+    this.tasks.add(record);
+    return true;
+  }
+
+  async stop(timeoutMs: number): Promise<boolean> {
+    this.accepting = false;
+    this.generation += 1;
+    const pending = [...this.tasks];
+    for (const record of pending) record.suppressTargetClose = true;
+    if (pending.length === 0) return true;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const drained = Promise.allSettled(pending.map((record) => record.promise)).then(() => true);
+    const timedOut = new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), Math.max(0, timeoutMs));
+    });
+    const completed = await Promise.race([drained, timedOut]);
+    if (timer) clearTimeout(timer);
+    if (!completed) {
+      try {
+        this.options.onTimeout?.(this.tasks.size);
+      } catch {
+        // Timeout reporting is best effort and must not break shutdown.
+      }
+    }
+    return completed;
+  }
+
+  resume(): void {
+    this.accepting = true;
+  }
+}


### PR DESCRIPTION
## Description

Fix the shutdown race from #329 by tracking asynchronous target setup work, isolating instrumentation state per browser incarnation, and draining or safely retiring old-generation work before the browser is closed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test addition/update

## Related Issues

Closes #329

## Changes Made

- Add a generation-fenced `TargetTaskTracker` that rejects new work after shutdown starts.
- Track asynchronous target setup from target-created and target-changed listeners.
- Stop accepting work, advance generation, and perform a bounded drain before plugin/browser shutdown.
- Drop strong references to timed-out task records while preserving late-rejection containment.
- Allocate and capture a fresh instrumentation manager for each browser incarnation so late old-generation work cannot mutate the relaunched browser manager.
- Suppress only actual Puppeteer `TargetCloseError` or anchored protocol Target/Session-close errors from intentional shutdown; ordinary errors continue through `onError`.
- Add regressions for stop, generation changes, timeout detachment, late rejection, strict error classification, and an executable isolation proof where late old-generation completion mutates only the retired manager.

## Testing

- [x] I have tested this locally
- [x] I have added/updated unit tests
- [x] All existing API tests pass
- [x] API build passes
- Focused tracker tests: `10/10 PASS`
- Full API suite: `83 passed / 2 skipped`
- API build: PASS
- Isolated 20-iteration Session/CDP/12-page/exact-release canary: `20/20 PASS`; the API remained healthy after every exact release and logs contained `0` `TargetCloseError|Target closed` matches.

## Exact Candidate

- Upstream base: `5880b48c1af107219ff3d904edbb8f6b76bea9b6`
- Head: `e5eaefd6437dcef0b049e44992f811eb0f4e380a`
- Tree: `fe3df8b47ebd31568ad9c1f2cc81c88298db06c9`
- Exact candidate diff SHA-256: `cb1fb5c4fe73f7e13c6071e80f6e69ff2b0de8b423bb8313648a43a69c265276`

## Additional Notes

`npm run lint -w api` is unavailable on the upstream base because ESLint reports no configuration file; this PR does not alter lint configuration. No dependency versions are changed.
