### PR TITLE
fix(cdp): only claim request interception when a blocking feature is on

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -372,9 +372,16 @@ export class CDPService extends EventEmitter {
           );
         }
 
-        await page.setRequestInterception(true);
+        // Request interception owns the CDP Fetch domain. Chrome dispatches a paused request to
+        // every session that enabled Fetch, and the first `continueRequest` wins, so holding it
+        // unconditionally silently breaks clients that drive their own interception over CDP
+        // (Playwright `route`, Puppeteer `setRequestInterception`). Only claim it when a blocking
+        // feature is actually configured for this session.
+        if (this.requiresRequestInterception()) {
+          await page.setRequestInterception(true);
 
-        page.on("request", (request) => this.handlePageRequest(request, page));
+          page.on("request", (request) => this.handlePageRequest(request, page));
+        }
 
         page.on("response", (response) => {
           if (response.url().startsWith("file://")) {
@@ -389,6 +396,24 @@ export class CDPService extends EventEmitter {
     } else if (target.type() === TargetType.BACKGROUND_PAGE) {
       this.logger.info(`[CDPService] Background page created: ${target.url()}`);
     }
+  }
+
+  private requiresRequestInterception(): boolean {
+    if (this.launchConfig?.blockAds) return true;
+    if (this.compiledUrlPatterns.length > 0) return true;
+
+    const optimize = this.launchConfig?.optimizeBandwidth;
+    if (typeof optimize === "object") {
+      return Boolean(
+        optimize.blockImages ||
+          optimize.blockMedia ||
+          optimize.blockStylesheets ||
+          optimize.blockHosts?.length ||
+          optimize.blockUrlPatterns?.length,
+      );
+    }
+
+    return Boolean(optimize);
   }
 
   private async handlePageRequest(request: HTTPRequest, page: Page) {


### PR DESCRIPTION
## Problem

`CDPService` calls `page.setRequestInterception(true)` on every page target, unconditionally:

```ts
await page.setRequestInterception(true);
page.on("request", (request) => this.handlePageRequest(request, page));
```

Puppeteer implements request interception with the CDP **`Fetch`** domain. Chrome dispatches a paused request to *every* session that has enabled `Fetch`, and the first `Fetch.continueRequest` wins — later ones fail with `Invalid InterceptionId`.

That means any client connected over CDP that drives its own interception (Playwright `context.route`, Puppeteer `setRequestInterception`) silently loses. `handlePageRequest` continues the request immediately, while the connected client's handler is typically doing async work first, so the client's modifications to the URL, headers, or post body are dropped. The request still goes through, so it fails as wrong behaviour rather than a clear error.

We hit this driving a third-party challenge solver that relays a request by rewriting it in flight with `route.continue({ url })` / `route.continue({ postData })`. The rewrite never reached the wire.

## Change

Claim the `Fetch` domain only when a blocking feature is actually configured for the session:

- `blockAds`
- `optimizeBandwidth` (any of `blockImages` / `blockMedia` / `blockStylesheets` / `blockHosts` / `blockUrlPatterns`)
- a compiled URL pattern list

Sessions that ask for no blocking now leave `Fetch` free for the connected client. Sessions that do ask for blocking are unchanged.

## Note on the `file://` guard

`handlePageRequest` also ends the session on a `file://` **request**. On sessions that no longer intercept, that specific check goes away. The separate `file://` **response** handler registered right below it is untouched and still ends the session, which is the case that matters for exfiltration — a `file://` request that never yields a response also never returns data.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Session with no blocking options: connected Playwright client's `route.continue({ url })` takes effect
- [ ] Session with `blockAds: true`: ads still blocked
- [ ] Session with `optimizeBandwidth: { blockImages: true }`: images still blocked

Made with [Cursor](https://cursor.com)