### PR TITLE
fix(sessions): return the browser version instead of session data

### DIFF
--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -213,7 +213,7 @@ export const handleGetSessionLiveDetails = async (
 
     const validPagesInfo = pagesInfo.filter((page) => page !== null);
 
-    const browserVersion = await server.cdpService.getBrowserState();
+    const browserVersion = await server.cdpService.getBrowserVersion();
 
     const browserState = {
       status: server.sessionService.activeSession.status,

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -210,6 +210,10 @@ export class CDPService extends EventEmitter {
     return this.browserInstance;
   }
 
+  public async getBrowserVersion(): Promise<string> {
+    return this.browserInstance ? this.browserInstance.version() : "";
+  }
+
   public getLaunchConfig(): BrowserLauncherOptions | undefined {
     return this.launchConfig;
   }

--- a/api/src/services/cdp/cdp.service.version.test.ts
+++ b/api/src/services/cdp/cdp.service.version.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { CDPService } from "./cdp.service.js";
+
+// getBrowserVersion only reads this.browserInstance, so we can exercise it
+// against a stand-in without constructing the full service.
+const callGetBrowserVersion = (browserInstance: unknown) =>
+  (CDPService.prototype.getBrowserVersion as () => Promise<string>).call({ browserInstance });
+
+describe("CDPService.getBrowserVersion", () => {
+  it("returns the browser version string, not a stringified object", async () => {
+    const version = "Chrome/150.0.7871.124";
+    const result = await callGetBrowserVersion({ version: async () => version });
+    expect(result).toBe(version);
+    expect(result).not.toBe("[object Object]");
+  });
+
+  it("returns an empty string when the browser is not initialized", async () => {
+    expect(await callGetBrowserVersion(null)).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #332.

The live session details endpoint returned `"[object Object]"` for `browserVersion`. The handler assigned `cdpService.getBrowserState()` — which resolves to a `SessionData` object (cookies, localStorage, …) — straight into the `z.string()` `browserVersion` field, so it got generic-stringified.

Added a `getBrowserVersion()` accessor on the CDP service that returns `browserInstance.version()` (e.g. `Chrome/150.0.7871.124`), or an empty string when the browser isn't up, and switched the handler to use it. Added a small test asserting the version string is preserved rather than passed through object stringification.