### PR TITLE
fix(cdp): use wss query param for secure DevTools debugger endpoint

### DIFF
--- a/api/src/modules/cdp/cdp.routes.test.ts
+++ b/api/src/modules/cdp/cdp.routes.test.ts
@@ -1,0 +1,65 @@
+import Fastify, { FastifyInstance } from "fastify";
+import { describe, it, expect, afterEach } from "vitest";
+import { schemas } from "../../plugins/schemas.js";
+import cdpRoutes from "./cdp.routes.js";
+
+const DEBUGGER_URL = "https://browser.example.com/devtools/devtools_app.html";
+
+/**
+ * Builds a bare Fastify instance with only the CDP routes and a stubbed cdpService,
+ * so the redirect can be asserted without booting a real browser.
+ */
+async function buildApp(debuggerWsUrl: string): Promise<FastifyInstance> {
+  const app = Fastify();
+
+  for (const schema of schemas) {
+    app.addSchema(schema);
+  }
+
+  app.decorate("cdpService", {
+    getDebuggerUrl: () => DEBUGGER_URL,
+    getDebuggerWsUrl: (_pageId?: string) => debuggerWsUrl,
+  } as FastifyInstance["cdpService"]);
+
+  await app.register(cdpRoutes);
+  await app.ready();
+
+  return app;
+}
+
+describe("GET /devtools/inspector.html", () => {
+  let app: FastifyInstance | undefined;
+
+  afterEach(async () => {
+    await app?.close();
+    app = undefined;
+  });
+
+  it("uses the wss query param without the scheme when the endpoint is secure", async () => {
+    app = await buildApp("wss://browser.example.com/devtools/page/page-123");
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/devtools/inspector.html?pageId=page-123",
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe(
+      `${DEBUGGER_URL}?wss=browser.example.com/devtools/page/page-123`,
+    );
+  });
+
+  it("uses the ws query param without the scheme when the endpoint is insecure", async () => {
+    app = await buildApp("ws://localhost:9223/devtools/page/page-123");
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/devtools/inspector.html?pageId=page-123",
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe(
+      `${DEBUGGER_URL}?ws=localhost:9223/devtools/page/page-123`,
+    );
+  });
+});

--- a/api/src/modules/cdp/cdp.routes.ts
+++ b/api/src/modules/cdp/cdp.routes.ts
@@ -19,11 +19,11 @@ async function routes(server: FastifyInstance) {
       request: FastifyRequest<{ Querystring: z.infer<typeof cdpSchemas.GetDevtoolsUrlSchema> }>,
       reply: FastifyReply,
     ) => {
-      return reply.redirect(
-        `${server.cdpService.getDebuggerUrl()}?ws=${server.cdpService
-          .getDebuggerWsUrl(request.query.pageId)
-          .replace("ws:", "")}`,
-      );
+      const debuggerWsUrl = new URL(server.cdpService.getDebuggerWsUrl(request.query.pageId));
+      const queryParam = debuggerWsUrl.protocol === "wss:" ? "wss" : "ws";
+      const endpoint = `${debuggerWsUrl.host}${debuggerWsUrl.pathname}${debuggerWsUrl.search}`;
+
+      return reply.redirect(`${server.cdpService.getDebuggerUrl()}?${queryParam}=${endpoint}`);
     },
   );
 }


### PR DESCRIPTION
## Description

When Steel is self-hosted with `USE_SSL=true`, the DevTools inspector redirect is generated with the `ws` query parameter while its value is a full `wss://` URL, so the DevTools frontend fails to connect.

`cdp.routes.ts` always used `?ws=` and stripped the scheme with `.replace("ws:", "")`. With `USE_SSL=true` the debugger URL starts with `wss:`, the replacement doesn't match, and the full `wss://…` stays inside the `ws` parameter.

The fix parses the debugger WS URL and derives both the query parameter and the endpoint from it: `wss:` → `?wss=`, anything else → `?ws=`, with the endpoint built from `host` + `pathname` + `search` instead of string-replacing the scheme.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/update

## Related Issues

Closes #328

## Changes Made
- [x] `api/src/modules/cdp/cdp.routes.ts` - derive the query param from the WS URL protocol and build the endpoint from `host` + `pathname` + `search`
- [x] `api/src/modules/cdp/cdp.routes.test.ts` - new file, integration tests for the redirect route
- [x] No functionality removed

**Behaviour change worth noting:** on plain HTTP the old `.replace("ws:", "")` left a leading double slash (`//localhost:9223/devtools/page/<id>`). The new implementation produces `localhost:9223/devtools/page/<id>`, the canonical form DevTools expects. Functionally equivalent for the frontend, but not byte-identical on the `USE_SSL=false` path - flagging it in case that matters.

## Testing
- [x] I have tested this locally
- [ ] I have added/updated unit tests
- [x] I have added/updated integration tests
- [ ] I have tested with Docker
- [x] All existing tests pass

Added `cdp.routes.test.ts` covering both the `wss://` and `ws://` cases via `fastify.inject()` on the redirect route, asserting the 302 `location` header. `cdpService` is stubbed, so no browser is launched.

I verified the tests fail against the previous implementation (`?ws=wss://…` for the secure case, `?ws=//localhost…` for the plain case) before restoring the fix.

`npm test` passes: 10 files, 75 tests, 2 skipped. Note this is the first test under `src/modules/` - happy to move it if you'd prefer a different location.

## Documentation
- [ ] I have updated relevant documentation
- [ ] I have added JSDoc comments for new public APIs
- [ ] I have updated the README if needed
- [ ] I have updated the CHANGELOG if needed

No documentation changes needed - this is an internal redirect fix with no public API surface.

## Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

## Breaking Changes

Not a breaking change. See the note under "Changes Made" about the `//host` → `host` normalisation on the plain HTTP path.