### PR TITLE
fix(sessions): read proxy byte counters after the proxy is closed

### DIFF
--- a/api/src/services/session.service.test.ts
+++ b/api/src/services/session.service.test.ts
@@ -1,0 +1,117 @@
+import type { FastifyBaseLogger } from "fastify";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IProxyServer } from "../utils/proxy.js";
+import type { CDPService } from "./cdp/cdp.service.js";
+import type { FileService } from "./file.service.js";
+import type { SeleniumService } from "./selenium.service.js";
+import { SessionService } from "./session.service.js";
+
+const TX_BYTES = 4096;
+const RX_BYTES = 8192;
+
+/**
+ * Mirrors the accounting of the real ProxyServer: proxy-chain only reports
+ * transfer stats through `connectionClosed`, so long-lived CONNECT tunnels
+ * contribute nothing until the server is closed.
+ */
+class FakeProxyServer implements IProxyServer {
+  public readonly url = "http://127.0.0.1:1234";
+  public txBytes = 0;
+  public rxBytes = 0;
+  public closeCount = 0;
+
+  constructor(public readonly upstreamProxyUrl: string) {}
+
+  async listen(): Promise<void> {}
+
+  async close(): Promise<void> {
+    this.closeCount++;
+    this.txBytes += TX_BYTES;
+    this.rxBytes += RX_BYTES;
+  }
+}
+
+const createService = () => {
+  const cdpService = {
+    getUserAgent: vi.fn().mockReturnValue("test-user-agent"),
+    getDimensions: vi.fn().mockReturnValue({ width: 1920, height: 1080 }),
+    startNewSession: vi.fn().mockResolvedValue(undefined),
+    endSession: vi.fn().mockResolvedValue(undefined),
+    launch: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  } as unknown as CDPService;
+
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as FastifyBaseLogger;
+
+  return new SessionService({
+    cdpService,
+    seleniumService: { close: vi.fn() } as unknown as SeleniumService,
+    fileService: {} as unknown as FileService,
+    logger,
+  });
+};
+
+const startProxiedSession = async (service: SessionService) => {
+  const proxies: FakeProxyServer[] = [];
+  service.setProxyFactory((proxyUrl) => {
+    const proxy = new FakeProxyServer(proxyUrl);
+    proxies.push(proxy);
+    return proxy;
+  });
+
+  await service.startSession({
+    proxyUrl: "http://user:pass@proxy.example.com:8080",
+    timezone: "UTC",
+    credentials: undefined,
+  });
+
+  return proxies;
+};
+
+describe("SessionService.endSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports proxy byte counters tallied after the proxy server is closed", async () => {
+    const service = createService();
+    const [proxy] = await startProxiedSession(service);
+
+    // Counters are still empty while the session is live, exactly as in production.
+    expect(service.activeSession.proxyTxBytes).toBe(0);
+    expect(service.activeSession.proxyRxBytes).toBe(0);
+
+    const released = await service.endSession();
+
+    expect(proxy.closeCount).toBe(1);
+    expect(released.proxyTxBytes).toBe(TX_BYTES);
+    expect(released.proxyRxBytes).toBe(RX_BYTES);
+  });
+
+  it("keeps the tallied counters on the archived past session", async () => {
+    const service = createService();
+    await startProxiedSession(service);
+
+    await service.endSession();
+
+    expect(service.pastSessions).toHaveLength(1);
+    expect(service.pastSessions[0].proxyTxBytes).toBe(TX_BYTES);
+    expect(service.pastSessions[0].proxyRxBytes).toBe(RX_BYTES);
+  });
+
+  it("reports zero for a session that ran without a proxy", async () => {
+    const service = createService();
+    await service.startSession({ timezone: "UTC", credentials: undefined });
+
+    const released = await service.endSession();
+
+    expect(released.proxyTxBytes).toBe(0);
+    expect(released.proxyRxBytes).toBe(0);
+  });
+});

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -281,10 +281,8 @@ export class SessionService {
     this.activeSession.duration =
       new Date().getTime() - new Date(this.activeSession.createdAt).getTime();
 
-    if (this.activeSession.proxyServer) {
-      this.activeSession.proxyTxBytes = this.activeSession.proxyServer.txBytes;
-      this.activeSession.proxyRxBytes = this.activeSession.proxyServer.rxBytes;
-    }
+    // Captured here because resetSessionInfo clears the reference on this same object
+    const proxyServer = this.activeSession.proxyServer;
 
     if (this.activeSession.isSelenium) {
       this.seleniumService.close();
@@ -299,6 +297,11 @@ export class SessionService {
       id: uuidv4(),
       status: "idle",
     });
+
+    // Byte counters only advance when a connection closes, so they are not final
+    // until resetSessionInfo has closed the proxy server above
+    releasedSession.proxyTxBytes = proxyServer?.txBytes ?? 0;
+    releasedSession.proxyRxBytes = proxyServer?.rxBytes ?? 0;
 
     this.pastSessions.push(releasedSession);
 


### PR DESCRIPTION
## Description

A session configured with `proxyUrl` reports `proxyTxBytes: 0` and `proxyRxBytes: 0` even though the proxy log proves traffic was routed.

`proxy-chain` only exposes byte totals when a connection closes - `ProxyServer` increments `txBytes`/`rxBytes` from the `connectionClosed` handler, never during transfer. An HTTPS CONNECT tunnel stays open for the whole session, so its bytes are invisible until the proxy is torn down. `endSession()` read the counters before `resetSessionInfo()` closed the proxy, capturing zeros.

The fix moves the read to after the proxy has been closed.

**One subtlety worth flagging:** `releasedSession` is the same object reference as `this.activeSession`, and `resetSessionInfo()` sets `proxyServer = undefined` on it. Simply moving the existing block below `resetSessionInfo()` therefore reads `undefined` and silently keeps reporting zeros - it looks correct and isn't. The `proxyServer` reference is captured before the call instead.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/update

## Related Issues

Closes #331

## Changes Made
- [x] `api/src/services/session.service.ts` - capture the `proxyServer` reference before `resetSessionInfo()`, read the counters after it has closed the proxy
- [x] `api/src/services/session.service.test.ts` - new file, first test covering this service
- [x] No functionality removed

Ordering is otherwise unchanged: Chrome still shuts down before the proxy is force-closed.

## Testing
- [x] I have tested this locally
- [x] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested with Docker
- [x] All existing tests pass

The test injects a fake proxy via `setProxyFactory` whose counters only advance in `close()` - the same semantics as `proxy-chain`. It asserts the counters are still zero while the session is live (otherwise the fake would prove nothing), then non-zero on the released session and in `pastSessions`. A third case covers a session with no proxy.

Verified against **both** failure modes:
- the original code (read before `resetSessionInfo`) → fails, `expected +0 to be 4096`
- the naive fix (block moved below without capturing the reference) → fails identically, catching the aliasing trap described above

Note: the issue mentions "passed the session-service regression", but there was no test covering `session.service.ts` - hence this one.

## Documentation
- [ ] I have updated relevant documentation
- [ ] I have added JSDoc comments for new public APIs
- [ ] I have updated the README if needed
- [ ] I have updated the CHANGELOG if needed

Two inline comments explain the ordering constraint, since nothing in the code otherwise signals that the capture must precede `resetSessionInfo()`.

## Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

## Breaking Changes

Not a breaking change.

## Screenshots (if applicable)

N/A - no UI changes.

## Additional Notes

Out of scope for this PR, but noticed while working on it: `api/tsconfig.test.json` extends `"../tsconfig.json"`, which resolves to the repo root where no such file exists. Nothing currently uses it (neither `npm test` nor `npm run build`), so it has never surfaced - happy to open a separate issue if useful.

I used an AI assistant to help investigate and draft the fix and tests. I reviewed the code, traced the ordering in `proxy-chain` myself, and verified the tests fail against both the original code and the naive fix before restoring the working version.

---

## Reviewer Checklist
- [ ] Code follows project conventions and style
- [ ] Changes are well-tested
- [ ] Documentation is updated appropriately
- [ ] No security concerns
- [ ] Performance impact is acceptable
- [ ] Breaking changes are properly documented