### PR TITLE
fix(ui): use height for live viewer default dimensions

### DIFF
--- a/api/src/templates/live-session-streamer.ejs
+++ b/api/src/templates/live-session-streamer.ejs
@@ -514,7 +514,7 @@
 
           // Default dimensions until we get first image
           const defaultWidth = <%= dimensions?.width || 1920 %>;
-          const defaultHeight = <%= dimensions?.width || 1080 %>;
+          const defaultHeight = <%= dimensions?.height || 1080 %>;
 
           // Function to set connection status
           function setConnectionStatus(online) {


### PR DESCRIPTION
## Description

The live session viewer used `dimensions.width` for both the default canvas width and height, so a non-square session (e.g. 1280×720) got the wrong aspect ratio until the first screencast frame arrived.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/update

## Related Issues

N/A — copy-paste typo found in `live-session-streamer.ejs`.

## Changes Made

- [x] Use `dimensions.height` (fallback 1080) for `defaultHeight` instead of `dimensions.width`

## Testing

- [ ] I have tested this locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested with Docker
- [ ] All existing tests pass

## Documentation

- [ ] I have updated relevant documentation
- [ ] I have added JSDoc comments for new public APIs
- [ ] I have updated the README if needed
- [ ] I have updated the CHANGELOG if needed

## Code Quality

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

## Breaking Changes

N/A

## Screenshots (if applicable)

N/A — one-line template fix; visible only before the first screencast frame.

## Additional Notes

`defaultWidth` was already `dimensions?.width || 1920`. Height incorrectly reused `width`.