### PR TITLE
fix(recorder): capture canvas frames created before injection

### DIFF
--- a/api/extensions/recorder/manifest.json
+++ b/api/extensions/recorder/manifest.json
@@ -20,7 +20,18 @@
       ],
       "js": [
         "dist/inject.js"
-      ]
+      ],
+      "run_at": "document_start"
+    },
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "dist/recorder-page.js"
+      ],
+      "run_at": "document_start",
+      "world": "MAIN"
     }
   ]
 }

--- a/api/extensions/recorder/src/inject.js
+++ b/api/extensions/recorder/src/inject.js
@@ -1,28 +1,29 @@
-import { record } from "rrweb";
-import { pack } from "@rrweb/packer";
+import { STEEL_RECORDER_SOURCE } from "./recorder-protocol.js";
 
-record({
-  emit: (event) => {
-    chrome.runtime.sendMessage(
-      {
-        type: "SAVE_EVENTS",
-        events: [event],
-      },
-      (response) => {
-        if (!response.success) {
-          console.error("[Recorder] Failed to save events:", response.error);
-        }
-      },
-    );
-  },
-  packFn: pack,
-  sampling: {
-    media: 800,
-  },
-  inlineImages: true,
-  collectFonts: true,
-  recordCrossOriginIframes: true,
-  recordCanvas: true,
+window.addEventListener("message", (event) => {
+  if (event.source !== window) {
+    return;
+  }
+  if (!event.data || event.data.source !== STEEL_RECORDER_SOURCE) {
+    return;
+  }
+
+  const events = event.data.events;
+  if (!Array.isArray(events) || events.length === 0) {
+    return;
+  }
+
+  chrome.runtime.sendMessage(
+    {
+      type: "SAVE_EVENTS",
+      events,
+    },
+    (response) => {
+      if (!response?.success) {
+        console.error("[Recorder] Failed to save events:", response?.error);
+      }
+    },
+  );
 });
 
 const enableWebRtcSites = ["meet.google.com", "zoom.us", "discord.com"];

--- a/api/extensions/recorder/src/recorder-page.js
+++ b/api/extensions/recorder/src/recorder-page.js
@@ -1,0 +1,3 @@
+import { startPageRecording } from "./start-page-recording.js";
+
+startPageRecording();

--- a/api/extensions/recorder/src/recorder-protocol.js
+++ b/api/extensions/recorder/src/recorder-protocol.js
@@ -1,0 +1,1 @@
+export const STEEL_RECORDER_SOURCE = "__steel_recorder_events__";

--- a/api/extensions/recorder/src/start-page-recording.js
+++ b/api/extensions/recorder/src/start-page-recording.js
@@ -1,0 +1,44 @@
+import { record } from "rrweb";
+import { pack } from "@rrweb/packer";
+import { STEEL_RECORDER_SOURCE } from "./recorder-protocol.js";
+
+export function startPageRecording(options = {}) {
+  const targetWindow = options.win || window;
+  if (targetWindow.__steelPageRecordingStarted) {
+    return () => {};
+  }
+  Object.defineProperty(targetWindow, "__steelPageRecordingStarted", {
+    value: true,
+    configurable: true,
+    enumerable: false,
+  });
+
+  const emit =
+    options.emit ||
+    ((event) => {
+      targetWindow.postMessage(
+        {
+          source: STEEL_RECORDER_SOURCE,
+          events: [event],
+        },
+        "*",
+      );
+    });
+
+  const recordOptions = {
+    emit,
+    sampling: {
+      media: 800,
+    },
+    inlineImages: true,
+    collectFonts: true,
+    recordCrossOriginIframes: true,
+    recordCanvas: true,
+  };
+
+  if (options.packFn !== null) {
+    recordOptions.packFn = options.packFn === undefined ? pack : options.packFn;
+  }
+
+  return record(recordOptions);
+}

--- a/api/extensions/recorder/src/start-page-recording.test.js
+++ b/api/extensions/recorder/src/start-page-recording.test.js
@@ -1,0 +1,240 @@
+/** @vitest-environment jsdom */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { STEEL_RECORDER_SOURCE } from "./recorder-protocol.js";
+import { startPageRecording } from "./start-page-recording.js";
+
+const IncrementalSourceCanvasMutation = 9;
+const EventTypeIncrementalSnapshot = 3;
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+function installCanvasPolyfill() {
+  class ImageDataPolyfill {
+    constructor(data, width, height) {
+      this.data = data;
+      this.width = width;
+      this.height = height;
+    }
+  }
+  window.ImageData = ImageDataPolyfill;
+  globalThis.ImageData = ImageDataPolyfill;
+
+  class CanvasRenderingContext2D {
+    constructor(canvas) {
+      this.canvas = canvas;
+    }
+    fillRect() {}
+    clearRect() {}
+    drawImage() {}
+    getImageData(_x, _y, width, height) {
+      return new ImageDataPolyfill(new Uint8ClampedArray(width * height * 4), width, height);
+    }
+  }
+
+  class WebGLRenderingContext {
+    constructor(canvas) {
+      this.canvas = canvas;
+    }
+    drawArrays() {}
+    clear() {}
+    getContextAttributes() {
+      return { preserveDrawingBuffer: false };
+    }
+  }
+
+  window.CanvasRenderingContext2D = CanvasRenderingContext2D;
+  window.WebGLRenderingContext = WebGLRenderingContext;
+
+  const contexts = new WeakMap();
+  Object.defineProperty(window.HTMLCanvasElement.prototype, "getContext", {
+    configurable: true,
+    writable: true,
+    value: function getContext(type) {
+      const existing = contexts.get(this);
+      if (existing) {
+        return existing.type === type ? existing.ctx : null;
+      }
+      if (type === "2d") {
+        const ctx = new CanvasRenderingContext2D(this);
+        contexts.set(this, { type, ctx });
+        return ctx;
+      }
+      if (type === "webgl" || type === "experimental-webgl") {
+        const ctx = new WebGLRenderingContext(this);
+        contexts.set(this, { type: "webgl", ctx });
+        return ctx;
+      }
+      return null;
+    },
+  });
+
+  Object.defineProperty(window.HTMLCanvasElement.prototype, "toDataURL", {
+    configurable: true,
+    writable: true,
+    value: function toDataURL() {
+      return "data:image/png;base64,iVBORw0KGgo=";
+    },
+  });
+}
+
+function canvasMutations(events) {
+  return events.filter(
+    (event) =>
+      event?.type === EventTypeIncrementalSnapshot &&
+      event?.data?.source === IncrementalSourceCanvasMutation,
+  );
+}
+
+async function flushCanvasMutations() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+      return;
+    }
+    setTimeout(resolve, 32);
+  });
+}
+
+installCanvasPolyfill();
+
+describe("page-world canvas recorder", () => {
+  let stop;
+
+  afterEach(() => {
+    if (typeof stop === "function") {
+      stop();
+    }
+    stop = undefined;
+    delete window.__steelPageRecordingStarted;
+    document.body.innerHTML = "";
+  });
+
+  it("emits CanvasMutation frames from a 2d context created before recording starts", async () => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 16;
+    canvas.height = 16;
+    document.body.appendChild(canvas);
+    const ctx = canvas.getContext("2d");
+    ctx.fillRect(0, 0, 4, 4);
+
+    const events = [];
+    stop = startPageRecording({
+      packFn: null,
+      emit: (event) => events.push(event),
+    });
+
+    ctx.fillRect(1, 1, 8, 8);
+    await flushCanvasMutations();
+
+    const mutations = canvasMutations(events);
+    expect(mutations.length).toBeGreaterThan(0);
+    expect(mutations.some((event) => event.data.commands?.some((command) => command.property === "fillRect"))).toBe(
+      true,
+    );
+  });
+
+  it("still emits CanvasMutation frames from a 2d context created after recording starts", async () => {
+    const events = [];
+    stop = startPageRecording({
+      packFn: null,
+      emit: (event) => events.push(event),
+    });
+
+    const canvas = document.createElement("canvas");
+    canvas.width = 16;
+    canvas.height = 16;
+    document.body.appendChild(canvas);
+    const ctx = canvas.getContext("2d");
+    ctx.fillRect(2, 2, 6, 6);
+    await flushCanvasMutations();
+
+    const mutations = canvasMutations(events);
+    expect(mutations.length).toBeGreaterThan(0);
+    expect(mutations.some((event) => event.data.commands?.some((command) => command.property === "fillRect"))).toBe(
+      true,
+    );
+  });
+
+  it("emits CanvasMutation frames from a webgl context created before recording starts", async () => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 16;
+    canvas.height = 16;
+    document.body.appendChild(canvas);
+    const gl = canvas.getContext("webgl");
+    gl.drawArrays(0, 0, 3);
+
+    const events = [];
+    stop = startPageRecording({
+      packFn: null,
+      emit: (event) => events.push(event),
+    });
+
+    gl.drawArrays(0, 0, 6);
+    await flushCanvasMutations();
+
+    const mutations = canvasMutations(events);
+    expect(mutations.length).toBeGreaterThan(0);
+    expect(mutations.some((event) => event.data.commands?.some((command) => command.property === "drawArrays"))).toBe(
+      true,
+    );
+  });
+
+  it("does not lock an unused canvas to 2d so a later webgl context still works", () => {
+    const canvas = document.createElement("canvas");
+    document.body.appendChild(canvas);
+
+    stop = startPageRecording({
+      packFn: null,
+      emit: () => {},
+    });
+
+    const gl = canvas.getContext("webgl");
+    expect(gl).not.toBeNull();
+    expect(canvas.getContext("2d")).toBeNull();
+  });
+
+  it("forwards recorder events to the isolated world over postMessage", async () => {
+    const messages = [];
+    const onMessage = (event) => messages.push(event.data);
+    window.addEventListener("message", onMessage);
+
+    const canvas = document.createElement("canvas");
+    document.body.appendChild(canvas);
+    const ctx = canvas.getContext("2d");
+
+    stop = startPageRecording({ packFn: null });
+    ctx.fillRect(0, 0, 2, 2);
+    await flushCanvasMutations();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    window.removeEventListener("message", onMessage);
+    expect(messages.some((message) => message?.source === STEEL_RECORDER_SOURCE)).toBe(true);
+  });
+});
+
+describe("recorder extension wiring", () => {
+  it("runs rrweb in the page world at document_start", () => {
+    const manifest = JSON.parse(readFileSync(path.join(here, "..", "manifest.json"), "utf8"));
+    const pageWorld = manifest.content_scripts.find((script) => script.js.includes("dist/recorder-page.js"));
+    const isolated = manifest.content_scripts.find((script) => script.js.includes("dist/inject.js"));
+
+    expect(pageWorld).toMatchObject({
+      run_at: "document_start",
+      world: "MAIN",
+    });
+    expect(isolated.run_at).toBe("document_start");
+    expect(isolated.world).not.toBe("MAIN");
+  });
+
+  it("keeps chrome.runtime in the isolated script and does not start rrweb there", () => {
+    const inject = readFileSync(path.join(here, "inject.js"), "utf8");
+    expect(inject).toContain("STEEL_RECORDER_SOURCE");
+    expect(inject).toContain("chrome.runtime.sendMessage");
+    expect(inject).not.toMatch(/from ["']rrweb["']/);
+    expect(inject).not.toMatch(/\brecord\s*\(/);
+  });
+});

--- a/api/extensions/recorder/webpack.config.mjs
+++ b/api/extensions/recorder/webpack.config.mjs
@@ -10,6 +10,7 @@ export default {
   entry: {
     inject: path.resolve(__dirname, "src/inject.js"),
     background: path.resolve(__dirname, "src/background.js"),
+    "recorder-page": path.resolve(__dirname, "src/recorder-page.js"),
   },
   output: {
     filename: "[name].js",

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -1,8 +1,20 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const recorderRrwebEsm = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "extensions/recorder/node_modules/rrweb/es/rrweb/packages/rrweb/src/entries/all.js",
+);
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      rrweb: recorderRrwebEsm,
+    },
+  },
   test: {
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "extensions/recorder/src/**/*.test.js"],
     testTimeout: 30000,
   },
 });


### PR DESCRIPTION
## Description

I changed the session recorder so `recordCanvas: true` actually captures canvas frames on pages that create their context during initial render (maps, charts, etc.).

Previously the recorder content script ran rrweb in the isolated world. rrweb records canvas by patching `CanvasRenderingContext2D` / `WebGLRenderingContext` prototypes on the window it runs in, so those hooks never saw page `getContext` / draw calls. I checked a MapLibre-style path against the current recorder: the canvas shows up in the full snapshot, but there are no `CanvasMutation` events (`source: 9`).

The recorder now starts in the page world at `document_start`, and the isolated script only forwards events to the background worker. Contexts created after injection still record. I did not probe `getContext` on unused canvases, because that would lock them to 2d.

Closes #340

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/update

## Related Issues

Closes #340

## Changes Made

- [x] Run rrweb from a MAIN-world content script at `document_start`
- [x] Keep `chrome.runtime` in the isolated script and bridge events over `postMessage`
- [x] Preserve post-injection 2d/webgl recording and unused-canvas `getContext` behavior
- [x] Add regression coverage for preexisting 2d, preexisting webgl, post-injection 2d, and unused-canvas webgl

## Testing

- [x] I have tested this locally
- [x] I have added/updated unit tests
- [ ] I have added/updated integration tests
- [ ] I have tested with Docker
- [x] All existing tests pass

Verified with:

- before, on current `main`: isolated-world `record()` never patches page 2d/webgl prototypes, so `fillRect` / `drawArrays` after a pre-record `getContext` produce no `CanvasMutation` events
- after: `npm test -w api`  -  80 passed, 2 skipped
- `cd api/extensions/recorder && npm run build`  -  `inject.js` no longer bundles rrweb; `recorder-page.js` does

## Documentation

- [ ] I have updated relevant documentation
- [ ] I have added JSDoc comments for new public APIs
- [ ] I have updated the README if needed
- [ ] I have updated the CHANGELOG if needed

## Code Quality

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

## Breaking Changes

None.

## Screenshots (if applicable)

N/A

## Additional Notes

`run_at: document_start` alone would not have been enough. The hooks have to run in the page world.

background.js still tries `executeScript({ files: ["inject.js"] })` on tab complete. That path was already missing (the built file is `dist/inject.js`) and is unused now that the manifest content scripts own injection.

---

## Reviewer Checklist

- [ ] Code follows project conventions and style
- [ ] Changes are well-tested
- [ ] Documentation is updated appropriately
- [ ] No security concerns
- [ ] Performance impact is acceptable
- [ ] Breaking changes are properly documented
