### PR TITLE
fix(api): return the real browser version in live session details

### DIFF
--- a/api/src/modules/sessions/sessions.controller.ts
+++ b/api/src/modules/sessions/sessions.controller.ts
@@ -213,7 +213,7 @@ export const handleGetSessionLiveDetails = async (
 
     const validPagesInfo = pagesInfo.filter((page) => page !== null);
 
-    const browserVersion = await server.cdpService.getBrowserState();
+    const browserVersion = await server.cdpService.getBrowserVersion();
 
     const browserState = {
       status: server.sessionService.activeSession.status,

--- a/api/src/services/cdp/cdp.service.test.ts
+++ b/api/src/services/cdp/cdp.service.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { CDPService } from "./cdp.service.js";
+
+type BrowserVersionHost = {
+  browserInstance: { version: () => Promise<string> } | null;
+  logger: { warn: (message: string) => void };
+};
+
+const getBrowserVersion = (host: BrowserVersionHost): Promise<string> =>
+  CDPService.prototype.getBrowserVersion.call(host as unknown as CDPService);
+
+const logger = { warn: vi.fn() };
+
+describe("CDPService.getBrowserVersion", () => {
+  it("returns the version string reported by the browser", async () => {
+    const version = "Chrome/150.0.7871.124";
+
+    await expect(
+      getBrowserVersion({ browserInstance: { version: async () => version }, logger }),
+    ).resolves.toBe(version);
+  });
+
+  it("returns an empty string when no browser is running", async () => {
+    await expect(getBrowserVersion({ browserInstance: null, logger })).resolves.toBe("");
+  });
+
+  it("returns an empty string when the browser fails to report a version", async () => {
+    await expect(
+      getBrowserVersion({
+        browserInstance: {
+          version: async () => {
+            throw new Error("Target closed");
+          },
+        },
+        logger,
+      }),
+    ).resolves.toBe("");
+  });
+});

--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -210,6 +210,23 @@ export class CDPService extends EventEmitter {
     return this.browserInstance;
   }
 
+  /**
+   * Returns the browser version reported by the running browser instance,
+   * e.g. `Chrome/150.0.7871.124`. Returns an empty string when no browser is
+   * running or the version cannot be resolved.
+   */
+  public async getBrowserVersion(): Promise<string> {
+    if (!this.browserInstance) {
+      return "";
+    }
+    try {
+      return await this.browserInstance.version();
+    } catch (error) {
+      this.logger.warn(`[CDPService] Failed to resolve browser version: ${error}`);
+      return "";
+    }
+  }
+
   public getLaunchConfig(): BrowserLauncherOptions | undefined {
     return this.launchConfig;
   }


### PR DESCRIPTION
## Description

`GET /v1/sessions/:id/live-details` always returns `"[object Object]"` for `browserState.browserVersion`.

The handler calls `cdpService.getBrowserState()`:

```ts
const browserVersion = await server.cdpService.getBrowserState();
```

but `getBrowserState()` resolves to the session's `SessionData` (cookies, localStorage, sessionStorage, indexedDB) — it has nothing to do with the browser version. Since the response schema types `browserVersion` as `z.string()`, Fastify's serializer coerces that object with `String()`, so callers always see the literal `"[object Object]"`.

This PR adds `CDPService.getBrowserVersion()`, which returns the version reported by the running browser instance (e.g. `Chrome/150.0.7871.124`), and uses it in the live-details handler. It returns an empty string when no browser is running or the lookup throws (e.g. the target closed mid-request), so the endpoint keeps satisfying its schema instead of failing serialization.

Also dumping the whole session data (a full cookie jar plus localStorage/sessionStorage/indexedDB) on every live-details request was wasted work, so this is a small win there too.

### Before

```json
{ "browserState": { "browserVersion": "[object Object]", ... } }
```

### After

```json
{ "browserState": { "browserVersion": "Chrome/150.0.7871.124", ... } }
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Added `api/src/services/cdp/cdp.service.test.ts` covering the three paths: the reported version is passed through verbatim (not object-stringified), no running browser yields `""`, and a failing `version()` call yields `""`.

```
npm test -w api   # 10 files, 76 passed | 2 skipped
npx tsc --noEmit  # clean
```

## Checklist

- [x] Code follows project style guidelines (`prettier` run on touched files)
- [x] Tests pass
- [x] JSDoc added for the new public method
- [x] Commit message follows conventional format
- [x] No breaking changes

Fixes #332
