### PR TITLE
fix(cdp): apply requested session dimensions to browser screen metrics

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -72,6 +72,7 @@ import {
 import { BasePlugin, ShutdownReason } from "./plugins/core/base-plugin.js";
 import { PluginManager } from "./plugins/core/plugin-manager.js";
 import { isSimilarConfig, validateLaunchConfig, validateTimezone } from "./utils/validation.js";
+import { resolveScreenMetrics } from "./utils/screen-metrics.js";
 import { TargetInstrumentationManager } from "./instrumentation/target-manager.js";
 import {
   createBrowserLogger as createInstrumentationLogger,
@@ -1500,15 +1501,22 @@ export class CDPService extends EventEmitter {
 
   @traceable
   private async applyDeviceMetricsOverride(page: Page): Promise<void> {
-    const screen = this.fingerprintData?.fingerprint?.screen;
+    const screen = resolveScreenMetrics({
+      dimensions: this.currentSessionConfig?.dimensions ?? this.launchConfig?.dimensions,
+      fingerprintScreen: this.fingerprintData?.fingerprint?.screen,
+    });
+
     if (!screen) {
       this.logger.warn(
-        "[CDPService] No fingerprint screen data available, skipping Page.setDeviceMetricsOverride",
+        "[CDPService] No session dimensions or fingerprint screen data available, skipping Page.setDeviceMetricsOverride",
       );
       return;
     }
 
     const userAgent = this.getUserAgent() ?? "";
+    const isMobile =
+      this.launchConfig?.deviceConfig?.device === "mobile" ||
+      /phone|android|mobile/i.test(userAgent);
     const session = await page.createCDPSession();
     try {
       await session.send("Page.setDeviceMetricsOverride", {
@@ -1517,7 +1525,7 @@ export class CDPService extends EventEmitter {
         width: screen.width,
         height: screen.height,
         viewport: { width: screen.availWidth, height: screen.availHeight, scale: 1, x: 0, y: 0 },
-        mobile: /phone|android|mobile/i.test(userAgent),
+        mobile: isMobile,
         screenOrientation:
           screen.height > screen.width
             ? { angle: 0, type: "portraitPrimary" }

--- a/api/src/services/cdp/utils/screen-metrics.test.ts
+++ b/api/src/services/cdp/utils/screen-metrics.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { resolveScreenMetrics } from "./screen-metrics.js";
+
+const fingerprintScreen = {
+  width: 1920,
+  height: 1080,
+  availWidth: 1920,
+  availHeight: 1032,
+  devicePixelRatio: 2,
+};
+
+describe("resolveScreenMetrics", () => {
+  it("returns null when neither dimensions nor fingerprint screen are available", () => {
+    expect(resolveScreenMetrics({})).toBeNull();
+    expect(resolveScreenMetrics({ dimensions: null, fingerprintScreen: null })).toBeNull();
+  });
+
+  it("uses the fingerprint screen when no dimensions were requested", () => {
+    expect(resolveScreenMetrics({ fingerprintScreen })).toEqual(fingerprintScreen);
+  });
+
+  it("uses the requested dimensions when no fingerprint was generated", () => {
+    expect(resolveScreenMetrics({ dimensions: { width: 1234, height: 777 } })).toEqual({
+      width: 1234,
+      height: 777,
+      availWidth: 1234,
+      availHeight: 777,
+      devicePixelRatio: 1,
+    });
+  });
+
+  it("prefers the requested dimensions over a mismatched fingerprint screen", () => {
+    expect(
+      resolveScreenMetrics({ dimensions: { width: 1111, height: 700 }, fingerprintScreen }),
+    ).toEqual({
+      width: 1111,
+      height: 700,
+      // The available area is clamped to the screen it sits on.
+      availWidth: 1111,
+      availHeight: 700,
+      devicePixelRatio: 2,
+    });
+  });
+
+  it("keeps the fingerprint available area when it fits the requested dimensions", () => {
+    expect(
+      resolveScreenMetrics({ dimensions: { width: 1920, height: 1080 }, fingerprintScreen }),
+    ).toEqual(fingerprintScreen);
+  });
+
+  it("falls back to a device pixel ratio of 1 when the fingerprint has none", () => {
+    expect(
+      resolveScreenMetrics({
+        dimensions: { width: 800, height: 600 },
+        fingerprintScreen: { ...fingerprintScreen, devicePixelRatio: 0 },
+      }),
+    ).toMatchObject({ devicePixelRatio: 1 });
+  });
+
+  it("ignores non-positive dimensions and fingerprint values", () => {
+    expect(
+      resolveScreenMetrics({ dimensions: { width: 0, height: 600 }, fingerprintScreen }),
+    ).toEqual(fingerprintScreen);
+    expect(
+      resolveScreenMetrics({
+        dimensions: { width: 1024, height: 768 },
+        fingerprintScreen: { ...fingerprintScreen, availWidth: 0, availHeight: -1 },
+      }),
+    ).toEqual({
+      width: 1024,
+      height: 768,
+      availWidth: 1024,
+      availHeight: 768,
+      devicePixelRatio: 2,
+    });
+    expect(
+      resolveScreenMetrics({ fingerprintScreen: { ...fingerprintScreen, width: 0 } }),
+    ).toBeNull();
+  });
+});

--- a/api/src/services/cdp/utils/screen-metrics.ts
+++ b/api/src/services/cdp/utils/screen-metrics.ts
@@ -1,0 +1,69 @@
+export interface ScreenMetrics {
+  width: number;
+  height: number;
+  availWidth: number;
+  availHeight: number;
+  devicePixelRatio: number;
+}
+
+export interface ScreenMetricsSources {
+  /** Dimensions explicitly requested for the session, if any. */
+  dimensions?: { width: number; height: number } | null;
+  /** `screen` block of the generated fingerprint, if a fingerprint was generated. */
+  fingerprintScreen?: Partial<ScreenMetrics> | null;
+}
+
+const isPositive = (value: number | undefined): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0;
+
+/**
+ * Resolves the screen metrics a page should report.
+ *
+ * Explicitly requested dimensions win, since they are what the API reports back
+ * and what the browser window is sized to — the generated fingerprint is only
+ * used to fill in the values the request does not pin down (`avail*`,
+ * `devicePixelRatio`). When no dimensions were requested the fingerprint screen
+ * is used as-is, and when neither is available there is nothing coherent to
+ * override with, so `null` is returned.
+ */
+export function resolveScreenMetrics({
+  dimensions,
+  fingerprintScreen,
+}: ScreenMetricsSources): ScreenMetrics | null {
+  const devicePixelRatio = isPositive(fingerprintScreen?.devicePixelRatio)
+    ? fingerprintScreen!.devicePixelRatio!
+    : 1;
+
+  if (isPositive(dimensions?.width) && isPositive(dimensions?.height)) {
+    const { width, height } = dimensions!;
+    return {
+      width,
+      height,
+      // The available area can never exceed the screen it sits on.
+      availWidth: isPositive(fingerprintScreen?.availWidth)
+        ? Math.min(fingerprintScreen!.availWidth!, width)
+        : width,
+      availHeight: isPositive(fingerprintScreen?.availHeight)
+        ? Math.min(fingerprintScreen!.availHeight!, height)
+        : height,
+      devicePixelRatio,
+    };
+  }
+
+  if (isPositive(fingerprintScreen?.width) && isPositive(fingerprintScreen?.height)) {
+    const { width, height } = fingerprintScreen as ScreenMetrics;
+    return {
+      width,
+      height,
+      availWidth: isPositive(fingerprintScreen?.availWidth)
+        ? fingerprintScreen!.availWidth!
+        : width,
+      availHeight: isPositive(fingerprintScreen?.availHeight)
+        ? fingerprintScreen!.availHeight!
+        : height,
+      devicePixelRatio,
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Description

A session created with explicit `dimensions` can end up with a page that reports `outerWidth`/`outerHeight` of the requested size but `screen.width`/`screen.height` of `800x600` — a contradiction that is visible to any script on the page.

`applyDeviceMetricsOverride` read the screen block straight off the generated fingerprint and bailed out when there wasn't one:

```ts
const screen = this.fingerprintData?.fingerprint?.screen;
if (!screen) {
  this.logger.warn("... skipping Page.setDeviceMetricsOverride");
  return;
}
```

So every session without a fingerprint — an explicit `userAgent` (which short-circuits generation), `skipFingerprintInjection`, `SKIP_FINGERPRINT_INJECTION=true`, or a fingerprint generation failure — never gets a `Page.setDeviceMetricsOverride` at all. The window is still sized from `dimensions` through `--window-size`, so the outer window honours the request while `screen` stays at the headless default. The relaxed `screen: undefined` fingerprint fallback can produce the same mismatch, since the fingerprint's screen is then unrelated to the requested dimensions.

This PR resolves the metrics from the effective session dimensions first and falls back to the fingerprint screen, so the screen a page sees always describes the window it is in.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- Added `resolveScreenMetrics()` (`api/src/services/cdp/utils/screen-metrics.ts`): requested dimensions win; the fingerprint fills in `availWidth`/`availHeight`/`devicePixelRatio`, clamped to the screen; the fingerprint screen is used as-is when no dimensions were requested; `null` only when neither is available.
- `applyDeviceMetricsOverride` uses it, so an override is now applied whenever the session has dimensions, with or without a fingerprint.
- The `mobile` flag is now also derived from `deviceConfig.device`, not only from a user-agent regex — a mobile session with no fingerprint user agent was being reported as desktop.

### Behaviour

| Session | Before | After |
| --- | --- | --- |
| `dimensions: 1234x777`, no fingerprint | `screen` = `800x600` | `screen` = `1234x777` |
| `dimensions: 1234x777` + matching fingerprint | `screen` = `1234x777` | unchanged |
| no dimensions + fingerprint | fingerprint screen | unchanged |
| neither | override skipped | override skipped (warning updated) |

The common path — a fingerprint generated for the requested dimensions — produces byte-identical override arguments, since the fingerprint's `avail*` values already fit inside the screen and are kept by the clamp.

## Testing

Added `api/src/services/cdp/utils/screen-metrics.test.ts` (7 cases) covering each of the rows above plus the degenerate inputs (zero/negative width, missing `devicePixelRatio`).

```
npm test -w api   # 10 files, 80 passed | 2 skipped
npx tsc --noEmit  # clean
```

## Checklist

- [x] Code follows project style guidelines (`prettier` run on touched files)
- [x] Tests pass
- [x] JSDoc added for the new helper
- [x] Commit message follows conventional format
- [x] No breaking changes

Fixes #330
