### PR TITLE
fix(sessions): respect the caller-supplied userDataDir

### DIFF
--- a/api/src/services/session.service.test.ts
+++ b/api/src/services/session.service.test.ts
@@ -1,0 +1,102 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { env } from "../env.js";
+import type { BrowserLauncherOptions } from "../types/index.js";
+import type { CDPService } from "./cdp/cdp.service.js";
+import type { FileService } from "./file.service.js";
+import type { SeleniumService } from "./selenium.service.js";
+import { PERSISTENT_USER_DATA_DIR, SessionService, resolveUserDataDir } from "./session.service.js";
+
+const defaultUserDataDir = env.CHROME_USER_DATA_DIR || path.join(os.tmpdir(), "steel-chrome");
+
+describe("resolveUserDataDir", () => {
+  it("uses the directory the caller asked for", () => {
+    expect(resolveUserDataDir({ userDataDir: "/data/profiles/tenant-a" })).toBe(
+      "/data/profiles/tenant-a",
+    );
+  });
+
+  it("keeps distinct requested directories distinct", () => {
+    expect(resolveUserDataDir({ userDataDir: "/data/profiles/tenant-a" })).not.toBe(
+      resolveUserDataDir({ userDataDir: "/data/profiles/tenant-b" }),
+    );
+  });
+
+  it("prefers the requested directory over the persistent one", () => {
+    expect(resolveUserDataDir({ userDataDir: "/data/profiles/tenant-a", persist: true })).toBe(
+      "/data/profiles/tenant-a",
+    );
+  });
+
+  it("uses the persistent directory when persist is set without a path", () => {
+    expect(resolveUserDataDir({ persist: true })).toBe(PERSISTENT_USER_DATA_DIR);
+  });
+
+  it("falls back to the configured or ephemeral default", () => {
+    expect(resolveUserDataDir({})).toBe(defaultUserDataDir);
+    expect(resolveUserDataDir({ persist: false })).toBe(defaultUserDataDir);
+    expect(resolveUserDataDir({ userDataDir: "" })).toBe(defaultUserDataDir);
+  });
+});
+
+describe("SessionService.startSession", () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "steel-session-service-"));
+  let launchConfigs: BrowserLauncherOptions[] = [];
+
+  afterAll(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    launchConfigs = [];
+  });
+
+  const createService = () => {
+    const cdpService = {
+      getUserAgent: () => "test-user-agent",
+      getDimensions: () => ({ width: 1920, height: 1080 }),
+      startNewSession: vi.fn(async (config: BrowserLauncherOptions) => {
+        launchConfigs.push(config);
+      }),
+    } as unknown as CDPService;
+
+    return new SessionService({
+      cdpService,
+      seleniumService: {} as SeleniumService,
+      fileService: {} as FileService,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    });
+  };
+
+  const start = async (service: SessionService, userDataDir: string) =>
+    service.startSession({
+      userDataDir,
+      // Avoid the network lookup the fetcher would otherwise perform.
+      timezone: "UTC",
+      credentials: undefined,
+    });
+
+  it("launches the browser with the requested user data directory", async () => {
+    const service = createService();
+    const userDataDir = path.join(tmpRoot, "tenant-a");
+
+    await start(service, userDataDir);
+
+    expect(launchConfigs).toHaveLength(1);
+    expect(launchConfigs[0].userDataDir).toBe(userDataDir);
+    expect(fs.existsSync(userDataDir)).toBe(true);
+  });
+
+  it("keeps sessions that request different directories on different profiles", async () => {
+    const service = createService();
+    const tenantA = path.join(tmpRoot, "tenant-a");
+    const tenantB = path.join(tmpRoot, "tenant-b");
+
+    await start(service, tenantA);
+    await start(service, tenantB);
+
+    expect(launchConfigs.map((config) => config.userDataDir)).toEqual([tenantA, tenantB]);
+  });
+});

--- a/api/src/services/session.service.ts
+++ b/api/src/services/session.service.ts
@@ -50,6 +50,33 @@ const defaultSession = {
   solveCaptcha: false,
 };
 
+/**
+ * Directory used for profiles the caller asked to persist but gave no path for.
+ * Resolved relative to this module so it points at the package root both when
+ * running from `src` (tsx) and from the compiled `build` output.
+ */
+export const PERSISTENT_USER_DATA_DIR = path.join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "user-data-dir",
+);
+
+/**
+ * Resolves the Chrome user data directory for a session, in priority order:
+ * an explicitly requested `userDataDir`, then the persistent profile directory
+ * when `persist` is set, then the configured or ephemeral default.
+ */
+export function resolveUserDataDir(options: { userDataDir?: string; persist?: boolean }): string {
+  if (options.userDataDir) {
+    return options.userDataDir;
+  }
+  if (options.persist === true) {
+    return PERSISTENT_USER_DATA_DIR;
+  }
+  return env.CHROME_USER_DATA_DIR || path.join(os.tmpdir(), "steel-chrome");
+}
+
 export type ProxyFactory = (
   proxyUrl: string,
   options?: OptimizeBandwidthOptions,
@@ -177,10 +204,7 @@ export class SessionService {
       deviceConfig,
     });
 
-    const userDataDir =
-      options.userDataDir || options.persist === true
-        ? path.join(dirname(fileURLToPath(import.meta.url)), "..", "..", "user-data-dir")
-        : env.CHROME_USER_DATA_DIR || path.join(os.tmpdir(), "steel-chrome");
+    const userDataDir = resolveUserDataDir(options);
     await mkdir(userDataDir, { recursive: true });
 
     const defaultUserPreferences = {


### PR DESCRIPTION
## Description

Fixes #347.

`POST /v1/sessions` accepts a `userDataDir`, the controller forwards it, and `SessionService.startSession` then throws it away. The cause is operator precedence:

```ts
const userDataDir =
  options.userDataDir || options.persist === true
    ? path.join(dirname(fileURLToPath(import.meta.url)), "..", "..", "user-data-dir")
    : env.CHROME_USER_DATA_DIR || path.join(os.tmpdir(), "steel-chrome");
```

`||` binds tighter than `?:`, so this is `(userDataDir || persist === true) ? <persistent dir> : <default dir>` — the caller's path is only ever a truthiness test, and the three-way choice the code reads as is a two-way one in which the requested path can never win.

**Consequences**

- Profiles meant to be separate are shared. Sessions requesting `/data/profiles/tenant-a` and `/data/profiles/tenant-b` both land in the persistent directory, so cookies, `Local Storage` and `Login Data` from one session are the starting state of the next. The API returns 200 and nothing is logged, so the missing isolation is invisible.
- The guard against exactly that is defeated: `isSimilarConfig` compares `userDataDir` so a profile change forces a relaunch rather than reuse of the running browser instance — with both configs collapsing to the same string, that comparison can no longer see the difference.
- A session that asked for a directory but not `persist` writes a full Chrome profile into the install tree (`/app/api/user-data-dir` in the image), where it outlives the session and accumulates (related to #324).
- `CHROME_USER_DATA_DIR` (#194) sits on the branch that is never taken when a `userDataDir` is supplied.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- Extracted `resolveUserDataDir()` with the intended priority order — requested path → persistent directory when `persist` is set → `CHROME_USER_DATA_DIR` or the ephemeral default — and used it in `startSession`.
- Lifted the persistent directory to `PERSISTENT_USER_DATA_DIR`, resolved the same way as before (relative to this module, so it points at the package root from both `src` under tsx and the compiled `build` output).

| Request | Before | After |
| --- | --- | --- |
| `{ userDataDir: "/data/profiles/tenant-a" }` | `<pkg>/user-data-dir` | `/data/profiles/tenant-a` |
| `{ userDataDir: "/data/profiles/tenant-b" }` | `<pkg>/user-data-dir` | `/data/profiles/tenant-b` |
| `{ userDataDir: "…", persist: true }` | `<pkg>/user-data-dir` | the requested path |
| `{ persist: true }` | `<pkg>/user-data-dir` | unchanged |
| `{}` | `CHROME_USER_DATA_DIR` / tmp | unchanged |

Only the rows where a path was requested change; `persist` and default behaviour are untouched.

## Testing

Added `api/src/services/session.service.test.ts`: five cases over `resolveUserDataDir` for every combination of `userDataDir`/`persist`, plus two that drive `SessionService.startSession` with a stubbed CDP service and assert the resolved directory actually reaches the browser launch config and that two sessions requesting different directories stay on different profiles.

Verified the tests fail against the original expression and pass with the fix — reintroducing the old precedence turns 5 of the 7 red, while the `persist` and default cases stay green, so the suite pins the bug rather than the implementation:

```
 × resolveUserDataDir > uses the directory the caller asked for
 × resolveUserDataDir > keeps distinct requested directories distinct
 × resolveUserDataDir > prefers the requested directory over the persistent one
 ✓ resolveUserDataDir > uses the persistent directory when persist is set without a path
 ✓ resolveUserDataDir > falls back to the configured or ephemeral default
 × SessionService.startSession > launches the browser with the requested user data directory
 × SessionService.startSession > keeps sessions that request different directories on different profiles
```

```
npm test -w api   # 10 files, 80 passed | 2 skipped
npx tsc --noEmit  # clean
```

## Notes

The precedence itself was spotted before in #300, which its author closed unmerged before review — credit to @hamodywe for finding it first. This PR adds the regression tests and the surrounding analysis.

Making the option work means a caller-supplied path is now created and written to, which is what the option documents. That is the same trust level the rest of the unauthenticated control interface already assumes; if you would rather constrain it (e.g. require paths under a configured root), say the word and I'll add that here.

## Checklist

- [x] Code follows project style guidelines (`prettier` run on touched files)
- [x] Tests pass, and fail without the fix
- [x] JSDoc added for the new exports
- [x] Commit message follows conventional format
- [x] No breaking changes
