### PR TITLE
fix(files): rebuild dirty session archives

### DIFF
--- a/api/src/services/file.service.test.ts
+++ b/api/src/services/file.service.test.ts
@@ -1,0 +1,177 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { inflateRawSync } from "node:zlib";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FileService } from "./file.service.js";
+
+function unzipFiles(buffer: Buffer): Map<string, string> {
+  let endOfCentralDirectory = -1;
+
+  for (let offset = buffer.length - 22; offset >= 0; offset -= 1) {
+    if (buffer.readUInt32LE(offset) === 0x06054b50) {
+      endOfCentralDirectory = offset;
+      break;
+    }
+  }
+
+  if (endOfCentralDirectory === -1) {
+    throw new Error("ZIP end of central directory record not found");
+  }
+
+  const entryCount = buffer.readUInt16LE(endOfCentralDirectory + 10);
+  let centralDirectoryOffset = buffer.readUInt32LE(endOfCentralDirectory + 16);
+  const files = new Map<string, string>();
+
+  for (let index = 0; index < entryCount; index += 1) {
+    if (buffer.readUInt32LE(centralDirectoryOffset) !== 0x02014b50) {
+      throw new Error(`Invalid ZIP central directory entry at ${centralDirectoryOffset}`);
+    }
+
+    const compressionMethod = buffer.readUInt16LE(centralDirectoryOffset + 10);
+    const compressedSize = buffer.readUInt32LE(centralDirectoryOffset + 20);
+    const fileNameLength = buffer.readUInt16LE(centralDirectoryOffset + 28);
+    const extraLength = buffer.readUInt16LE(centralDirectoryOffset + 30);
+    const commentLength = buffer.readUInt16LE(centralDirectoryOffset + 32);
+    const localHeaderOffset = buffer.readUInt32LE(centralDirectoryOffset + 42);
+    const fileName = buffer
+      .subarray(centralDirectoryOffset + 46, centralDirectoryOffset + 46 + fileNameLength)
+      .toString("utf8");
+
+    if (!fileName.endsWith("/")) {
+      const localFileNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
+      const localExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
+      const dataStart = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+      const compressed = buffer.subarray(dataStart, dataStart + compressedSize);
+
+      if (compressionMethod !== 0 && compressionMethod !== 8) {
+        throw new Error(`Unsupported ZIP compression method ${compressionMethod}`);
+      }
+
+      const content = compressionMethod === 0 ? compressed : inflateRawSync(compressed);
+      files.set(fileName, content.toString("utf8"));
+    }
+
+    centralDirectoryOffset += 46 + fileNameLength + extraLength + commentLength;
+  }
+
+  return files;
+}
+
+describe("FileService session archives", () => {
+  let testDirectory: string | undefined;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (testDirectory) {
+      await fs.promises.rm(testDirectory, { recursive: true, force: true });
+      testDirectory = undefined;
+    }
+  });
+
+  async function createFileService() {
+    testDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), "steel-files-archive-"));
+    const baseFilesPath = path.join(testDirectory, "files");
+    const prebuiltArchiveDir = path.join(testDirectory, "archive");
+
+    return new FileService({
+      baseFilesPath,
+      prebuiltArchiveDir,
+      watchFiles: false,
+    });
+  }
+
+  it("rebuilds a stale archive with current root and nested entries for concurrent requests", async () => {
+    const fileService = await createFileService();
+    const baseFilesPath = fileService.getBaseFilesPath();
+
+    await fs.promises.writeFile(path.join(baseFilesPath, "stale.txt"), "stale content");
+    await fileService.getPrebuiltArchivePath();
+    await fs.promises.rm(path.join(baseFilesPath, "stale.txt"));
+
+    await fileService.saveFile({
+      filePath: "zip1.txt",
+      stream: Readable.from("zip content 1"),
+    });
+    await fileService.saveFile({
+      filePath: "subdir/zip2.txt",
+      stream: Readable.from("zip content 2"),
+    });
+
+    const [archivePath, concurrentArchivePath] = await Promise.all([
+      fileService.getPrebuiltArchivePath(),
+      fileService.getPrebuiltArchivePath(),
+    ]);
+    const archive = unzipFiles(await fs.promises.readFile(archivePath));
+
+    expect(concurrentArchivePath).toBe(archivePath);
+    expect([...archive.entries()]).toEqual([
+      ["subdir/zip2.txt", "zip content 2"],
+      ["zip1.txt", "zip content 1"],
+    ]);
+  });
+
+  it("rebuilds again when files change during an in-flight archive", async () => {
+    const fileService = await createFileService();
+    await fileService.saveFile({
+      filePath: "zip1.txt",
+      stream: Readable.from("zip content 1"),
+    });
+
+    const rename = fs.promises.rename.bind(fs.promises);
+    let releaseRename!: () => void;
+    const renameReleased = new Promise<void>((resolve) => {
+      releaseRename = resolve;
+    });
+    let signalRenameStarted!: () => void;
+    const renameStarted = new Promise<void>((resolve) => {
+      signalRenameStarted = resolve;
+    });
+
+    vi.spyOn(fs.promises, "rename").mockImplementationOnce(async (oldPath, newPath) => {
+      signalRenameStarted();
+      await renameReleased;
+      await rename(oldPath, newPath);
+    });
+
+    const archiveRequests = Promise.all([
+      fileService.getPrebuiltArchivePath(),
+      fileService.getPrebuiltArchivePath(),
+    ]);
+    await renameStarted;
+    await fileService.saveFile({
+      filePath: "nested/zip2.txt",
+      stream: Readable.from("zip content 2"),
+    });
+    releaseRename();
+
+    const [archivePath] = await archiveRequests;
+    expect([...unzipFiles(await fs.promises.readFile(archivePath)).entries()]).toEqual([
+      ["nested/zip2.txt", "zip content 2"],
+      ["zip1.txt", "zip content 1"],
+    ]);
+  });
+
+  it("retries archive creation after an early failure", async () => {
+    testDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), "steel-files-archive-"));
+    const baseFilesPath = path.join(testDirectory, "files");
+    const prebuiltArchiveDir = path.join(testDirectory, "blocked-archive");
+    const fileService = new FileService({ baseFilesPath, prebuiltArchiveDir, watchFiles: false });
+
+    await fileService.saveFile({
+      filePath: "zip1.txt",
+      stream: Readable.from("zip content 1"),
+    });
+    await fs.promises.writeFile(prebuiltArchiveDir, "not a directory");
+
+    await expect(fileService.getPrebuiltArchivePath()).rejects.toThrow();
+
+    await fs.promises.rm(prebuiltArchiveDir);
+    const archivePath = await fileService.getPrebuiltArchivePath();
+    expect([...unzipFiles(await fs.promises.readFile(archivePath)).entries()]).toEqual([
+      ["zip1.txt", "zip content 1"],
+    ]);
+  });
+});

--- a/api/src/services/file.service.ts
+++ b/api/src/services/file.service.ts
@@ -13,6 +13,12 @@ interface File {
   lastModified: Date;
 }
 
+export interface FileServiceOptions {
+  baseFilesPath?: string;
+  prebuiltArchiveDir?: string;
+  watchFiles?: boolean;
+}
+
 export class FileService {
   private baseFilesPath: string;
   private fileWatcher: FSWatcher | null = null;
@@ -21,12 +27,15 @@ export class FileService {
   private prebuiltArchivePath: string;
   private isArchiving: boolean = false;
   private currentArchivePromise: Promise<string | null> | null = null;
+  private archiveDirty = true;
   private archiveDebounceTime = 500;
   private debouncedCreateArchive: DebouncedFunc<() => Promise<string | null>>;
 
-  private constructor() {
-    this.baseFilesPath = env.NODE_ENV === "development" ? path.join(tmpdir(), "files") : "/files";
-    this.prebuiltArchiveDir = "/tmp/.steel";
+  public constructor(options: FileServiceOptions = {}) {
+    this.baseFilesPath =
+      options.baseFilesPath ??
+      (env.NODE_ENV === "development" ? path.join(tmpdir(), "files") : "/files");
+    this.prebuiltArchiveDir = options.prebuiltArchiveDir ?? "/tmp/.steel";
     this.prebuiltArchivePath = path.join(this.prebuiltArchiveDir, "files.zip");
 
     fs.mkdirSync(this.baseFilesPath, { recursive: true });
@@ -34,7 +43,9 @@ export class FileService {
     const boundCreateArchive = this._createArchive.bind(this);
     this.debouncedCreateArchive = debounce(boundCreateArchive, this.archiveDebounceTime);
 
-    this.initFileWatcher();
+    if (options.watchFiles !== false) {
+      this.initFileWatcher();
+    }
   }
 
   public static getInstance() {
@@ -46,16 +57,21 @@ export class FileService {
 
   private async handleFileAdd(filePath: string) {
     console.log(`[FileService] File added detected: ${filePath}`);
-    this.debouncedCreateArchive();
+    this.scheduleArchiveCreation();
   }
 
   private handleFileDelete(filePath: string) {
     console.log(`[FileService] File deleted detected: ${filePath}`);
-    this.debouncedCreateArchive();
+    this.scheduleArchiveCreation();
   }
 
   private handleDirChange(filePath: string) {
     console.log(`[FileService] Directory change detected: ${filePath}`);
+    this.scheduleArchiveCreation();
+  }
+
+  private scheduleArchiveCreation() {
+    this.archiveDirty = true;
     this.debouncedCreateArchive();
   }
 
@@ -81,7 +97,7 @@ export class FileService {
       .on("error", (error) => console.error(`Watcher error: ${error}`))
       .on("ready", () => {
         console.log("[FileService] Initial scan complete. Ready for changes.");
-        this.debouncedCreateArchive();
+        this.scheduleArchiveCreation();
       });
   }
 
@@ -128,7 +144,7 @@ export class FileService {
         lastModified: stats.mtime,
       };
       console.log(`File saved: ${safeFilePath}, Size: ${file.size}`);
-      this.debouncedCreateArchive();
+      this.scheduleArchiveCreation();
       return { ...file, path: safeFilePath };
     } catch (error) {
       console.error(`[FileService] Error saving file ${safeFilePath}:`, error);
@@ -269,7 +285,7 @@ export class FileService {
       }
       await fs.promises.unlink(safeFilePath);
       console.log(`[FileService] File deleted: ${safeFilePath}`);
-      this.debouncedCreateArchive();
+      this.scheduleArchiveCreation();
     } catch (unlinkError) {
       console.error(`Error unlinking file ${safeFilePath}:`, unlinkError);
       throw unlinkError;
@@ -327,7 +343,7 @@ export class FileService {
       }
     }
     console.log(`[FileService cleanupFiles] Files cleaned. Creating empty archive.`);
-    this.debouncedCreateArchive();
+    this.scheduleArchiveCreation();
   }
 
   public getBaseFilesPath(): string {
@@ -335,6 +351,13 @@ export class FileService {
   }
 
   public async getPrebuiltArchivePath(): Promise<string> {
+    this.debouncedCreateArchive.cancel();
+
+    while (this.currentArchivePromise || this.archiveDirty) {
+      await (this.currentArchivePromise ?? this._createArchive());
+      this.debouncedCreateArchive.cancel();
+    }
+
     return this.prebuiltArchivePath;
   }
 
@@ -353,6 +376,7 @@ export class FileService {
       return this.currentArchivePromise;
     }
 
+    this.archiveDirty = false;
     const archivePromise = new Promise<string | null>(async (resolvePromise, rejectPromise) => {
       if (this.isArchiving) {
         console.warn(
@@ -486,9 +510,14 @@ export class FileService {
       }
     });
 
-    this.currentArchivePromise = archivePromise.finally(() => {
-      this.currentArchivePromise = null;
-    });
+    this.currentArchivePromise = archivePromise
+      .catch((error) => {
+        this.archiveDirty = true;
+        throw error;
+      })
+      .finally(() => {
+        this.currentArchivePromise = null;
+      });
 
     return this.currentArchivePromise;
   }


### PR DESCRIPTION
## Summary
- mark the prebuilt session archive dirty whenever files or directories change
- make archive downloads wait for the latest rebuild, including writes during an in-flight archive
- recover cleanly after archive creation errors and serialize concurrent download requests

## Testing
- npm test -- --run api/src/services/file.service.test.ts
- 3 archive regression tests passed
- git diff --check

## Tracking
- [STE-2593](https://linear.app/nenlabs/issue/STE-2593/box-15-session-files-zip-omits-uploaded-root-files)