### PR TITLE
Add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ If you're looking to deploy to a cloud provider, we've got you covered.
 | Pre-built Docker Image (combined API + UI) | [![Deploy with Github Container Registry](https://img.shields.io/badge/GHCR-478CFF?style=for-the-badge&labelColor=478CFF&logo=github&logoColor=white)](https://github.com/steel-dev/steel-browser/pkgs/container/steel-browser) |
 | 1-click deploy to Railway | [![Deploy on Railway](https://img.shields.io/badge/Railway-B039CB?style=for-the-badge&labelColor=B039CB&logo=railway&logoColor=white)](https://railway.app/deploy/steelbrowser) |
 | 1-click deploy to Render | [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy) |
+| 1-click deploy to RepoCloud | [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Steel/) |
 
 
 ## 💻 Running Locally


### PR DESCRIPTION
Added RepoCloud as a one-click deployment option in the Quick Deploy table.

RepoCloud offers an easy way to deploy Steel Browser with one click at reduced cost. This adds a new row to the existing deployment methods table alongside Railway and Render.