### PR TITLE
fix(cdp): keep the DevTools inspector working when USE_SSL is enabled

### DIFF
--- a/api/src/modules/cdp/cdp.routes.ts
+++ b/api/src/modules/cdp/cdp.routes.ts
@@ -2,6 +2,7 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { z } from "zod";
 import { $ref } from "../../plugins/schemas.js";
 import cdpSchemas from "./cdp.schemas.js";
+import { buildDevtoolsFrontendUrl } from "../../utils/url.js";
 
 async function routes(server: FastifyInstance) {
   server.get(
@@ -20,9 +21,10 @@ async function routes(server: FastifyInstance) {
       reply: FastifyReply,
     ) => {
       return reply.redirect(
-        `${server.cdpService.getDebuggerUrl()}?ws=${server.cdpService
-          .getDebuggerWsUrl(request.query.pageId)
-          .replace("ws:", "")}`,
+        buildDevtoolsFrontendUrl(
+          server.cdpService.getDebuggerUrl(),
+          server.cdpService.getDebuggerWsUrl(request.query.pageId),
+        ),
       );
     },
   );

--- a/api/src/utils/url.test.ts
+++ b/api/src/utils/url.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDevtoolsFrontendUrl } from "./url.js";
+
+const frontend = "http://localhost:9222/devtools/devtools_app.html";
+const secureFrontend = "https://browser.example.com/devtools/devtools_app.html";
+const pageId = "A1B2C3D4E5F6";
+
+describe("buildDevtoolsFrontendUrl", () => {
+  it("passes an insecure endpoint through the ws parameter", () => {
+    const result = buildDevtoolsFrontendUrl(
+      frontend,
+      `ws://localhost:9222/devtools/page/${pageId}`,
+    );
+
+    expect(result).toBe(`${frontend}?ws=//localhost:9222/devtools/page/${pageId}`);
+  });
+
+  it("passes a secure endpoint through the wss parameter", () => {
+    const result = buildDevtoolsFrontendUrl(
+      secureFrontend,
+      `wss://browser.example.com/devtools/page/${pageId}`,
+    );
+
+    expect(result).toBe(
+      `${secureFrontend}?wss=//browser.example.com/devtools/page/${pageId}`,
+    );
+  });
+
+  it("never leaves a scheme in the parameter value", () => {
+    for (const endpoint of [
+      "ws://localhost:9222/devtools/page/x",
+      "wss://browser.example.com/devtools/page/x",
+    ]) {
+      const value = new URL(buildDevtoolsFrontendUrl(frontend, endpoint)).search;
+
+      expect(value).not.toContain("ws://");
+      expect(value).not.toContain("wss://");
+    }
+  });
+
+  it("does not hand a secure endpoint to the insecure parameter", () => {
+    // The frontend derives the scheme from the parameter name, so a wss endpoint
+    // announced as `ws` would be dialled as ws:// and blocked as mixed content.
+    const result = buildDevtoolsFrontendUrl(
+      secureFrontend,
+      `wss://browser.example.com/devtools/page/${pageId}`,
+    );
+
+    expect(result).not.toContain("?ws=");
+    expect(result).toContain("?wss=");
+  });
+
+  it("preserves the page id and the rest of the path", () => {
+    const result = buildDevtoolsFrontendUrl(
+      frontend,
+      `ws://127.0.0.1:9222/devtools/page/${pageId}`,
+    );
+
+    expect(result.endsWith(`/devtools/page/${pageId}`)).toBe(true);
+  });
+
+  it("keeps a non-default host and port intact", () => {
+    const result = buildDevtoolsFrontendUrl(
+      "https://cdp.example.com:8443/devtools/devtools_app.html",
+      "wss://cdp.example.com:8443/devtools/page/deadbeef",
+    );
+
+    expect(result).toBe(
+      "https://cdp.example.com:8443/devtools/devtools_app.html?wss=//cdp.example.com:8443/devtools/page/deadbeef",
+    );
+  });
+});

--- a/api/src/utils/url.ts
+++ b/api/src/utils/url.ts
@@ -21,6 +21,27 @@ export function getBaseUrl(protocolType: "http" | "ws" = "http"): string {
 }
 
 /**
+ * Builds the DevTools frontend URL for a debugger websocket endpoint.
+ *
+ * The frontend expects a scheme-less host/path and prepends the scheme itself,
+ * choosing it from which query parameter carries the value: `ws` becomes
+ * `ws://`, `wss` becomes `wss://`. A secure endpoint therefore has to be passed
+ * as `wss`, otherwise the frontend opens an insecure socket that an
+ * HTTPS-served frontend then blocks as mixed content.
+ *
+ * @param debuggerUrl Absolute URL of the DevTools frontend
+ * @param debuggerWsUrl Absolute ws:// or wss:// debugger endpoint
+ * @returns The frontend URL carrying the endpoint in the matching parameter
+ */
+export function buildDevtoolsFrontendUrl(debuggerUrl: string, debuggerWsUrl: string): string {
+  const isSecure = debuggerWsUrl.startsWith("wss:");
+  const parameter = isSecure ? "wss" : "ws";
+  const schemeless = debuggerWsUrl.replace(/^wss?:/, "");
+
+  return `${debuggerUrl}?${parameter}=${schemeless}`;
+}
+
+/**
  * Returns a fully qualified URL with the given path
  * @param path The path to append to the base URL
  * @param protocolType 'http' or 'ws' - determines the protocol prefix


### PR DESCRIPTION
Fixes #343.

## Problem

`GET /devtools/inspector.html` redirects to the DevTools frontend and passes the debugger endpoint along:

```ts
`${server.cdpService.getDebuggerUrl()}?ws=${server.cdpService
  .getDebuggerWsUrl(request.query.pageId)
  .replace("ws:", "")}`
```

`getDebuggerWsUrl()` returns `wss://…` when `USE_SSL` is on. `"wss://host/…".replace("ws:", "")` is a no-op, because the literal `ws:` never occurs in `wss:`. The frontend receives `ws=wss://host/…`, dials `ws://wss//host/…`, and the page CSP blocks it:

```
Connecting to 'ws://wss//<host>/devtools/page/<id>' violates CSP directive connect-src …
```

The inspector renders as a blank iframe. The live cast view (`/v1/sessions/debug`) is unaffected.

## Why stripping the scheme is not enough

The issue suggests `.replace(/^wss?:/, "")`. That fixes the malformed URL but introduces a quieter problem, because the frontend picks the scheme from *which parameter carries the value*:

```js
let e = Runtime.queryParam("ws"), t = Runtime.queryParam("wss");
if (e || t) { let s = e ? `ws://${e}` : `wss://${t}`; … }
```

Under `USE_SSL=true` the frontend is itself served over HTTPS. Handing it a secure endpoint through `ws` makes it open a plain `ws://` socket, which the browser then blocks as mixed content. So the parameter has to switch along with the scheme.

## Changes

- `utils/url.ts` — new `buildDevtoolsFrontendUrl(debuggerUrl, debuggerWsUrl)`. It strips `ws:` or `wss:` and emits the value under the matching parameter.
- `cdp.routes.ts` — the redirect uses the helper instead of building the query string inline.

| `USE_SSL` | Before | After |
|---|---|---|
| `false` | `?ws=//host/devtools/page/<id>` | `?ws=//host/devtools/page/<id>` — **byte-identical** |
| `true` | `?ws=wss://host/devtools/page/<id>` (broken) | `?wss=//host/devtools/page/<id>` |

The insecure path is deliberately unchanged, so this carries no regression risk for the default configuration.

## Testing

Added `api/src/utils/url.test.ts`, 6 cases: insecure endpoints keep using `ws`, secure endpoints move to `wss`, no scheme ever survives into the parameter value, a secure endpoint is never announced as `ws`, and the page id, host and non-default port are preserved.

```
✓ src/utils/url.test.ts (6 tests) 5ms
```

`tsc --noEmit -p api/tsconfig.json` is clean.

Credit to @marlien-gonsales — the report included the frontend-side evidence that made the parameter-name half of this obvious.
