### PR TITLE
fix(ui): render the session the viewer URL actually points at

### DIFF
--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -3,13 +3,13 @@ import { Badge } from "@/components/ui/badge";
 import { GlowingGreenDot } from "@/components/icons/GlowingGreenDot";
 import { useSessionsContext } from "@/hooks/use-sessions-context";
 import { SteelIcon } from "../icons/SessionIcon";
+import { useMatch } from "react-router-dom";
 
 export const Header = () => {
-  const { pathname } = window.location;
-  const currentSessionId =
-    pathname.includes("sessions") && pathname.split("/").pop() !== "sessions"
-      ? pathname.split("/").pop()
-      : null;
+  // Read the same route the viewer renders from. Parsing window.location by
+  // hand also never re-read on client-side navigation.
+  const match = useMatch("/sessions/:id");
+  const currentSessionId = match?.params.id ?? null;
 
   const { useSession } = useSessionsContext();
   const { data: session, isLoading } = useSession(currentSessionId!);

--- a/ui/src/containers/session-container.tsx
+++ b/ui/src/containers/session-container.tsx
@@ -15,6 +15,10 @@ export function SessionContainer() {
   if (isLoading) return <div>Loading...</div>;
   if (isError || !session) return <div>Error</div>;
 
+  // On the id-less route the query resolves to the first session, so take the
+  // id from the resolved session rather than passing undefined to children.
+  const sessionId = id ?? session.id;
+
   return (
     <div className="flex flex-col overflow-hidden items-center justify-center h-full w-full p-4">
       <div className="flex flex-col overflow-hidden items-center justify-center h-full w-full rounded-md bg-[var(--gray-2)] p-4 pt-2 gap-3">
@@ -35,12 +39,12 @@ export function SessionContainer() {
                 <ArrowLeftIcon className="w-4 h-4" />
               )}
             </Button>
-            <SessionViewer id={id!} />
+            <SessionViewer id={sessionId} />
           </div>
           {showConsole && (
             <div className="flex flex-col items-center overflow-hidden w-1/3 justify-center h-full text-primary gap-2">
               <div className="flex flex-col items-center overflow-hidden justify-center w-full h-full border border-[var(--gray-6)] rounded-md overflow-hidden">
-                {session && <SessionConsole id={id!} />}
+                <SessionConsole id={sessionId} />
               </div>
             </div>
           )}

--- a/ui/src/root-layout.tsx
+++ b/ui/src/root-layout.tsx
@@ -5,18 +5,28 @@ import { queryClient } from "./lib/query-client";
 import { SessionContainer } from "./containers/session-container";
 import { Header } from "@/components/header";
 import { Toaster } from "@/components/ui/toaster";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 export default function RootLayout() {
   return (
     <QueryClientProvider client={queryClient}>
       <SessionsProvider>
         <ThemeProvider defaultTheme="dark" storageKey="steel-ui-theme">
-          <div className="flex flex-col h-screen overflow-hidden max-h-screen items-center justify-center flex-1 bg-secondary text-primary-foreground">
-            <Header />
-            <div className="flex flex-col overflow-hidden flex-1 w-full">
-              <SessionContainer />
+          {/* The combined API image serves the UI under /ui (vite --base=/ui),
+              so the router has to match routes against that base too. */}
+          <BrowserRouter basename={import.meta.env.BASE_URL}>
+            <div className="flex flex-col h-screen overflow-hidden max-h-screen items-center justify-center flex-1 bg-secondary text-primary-foreground">
+              <Header />
+              <div className="flex flex-col overflow-hidden flex-1 w-full">
+                <Routes>
+                  <Route path="/sessions/:id" element={<SessionContainer />} />
+                  {/* Every other path keeps rendering the viewer, as it did
+                      before routing existed. */}
+                  <Route path="*" element={<SessionContainer />} />
+                </Routes>
+              </div>
             </div>
-          </div>
+          </BrowserRouter>
           <Toaster />
         </ThemeProvider>
       </SessionsProvider>


### PR DESCRIPTION
Fixes #333.

## Problem

`SessionContainer` reads the session id with `useParams()`, but nothing in `ui/src` ever mounted a Router — not `App.tsx`, not `main.tsx`, not `root-layout.tsx`. Outside Router context `useParams()` returns `{}`, so `id` was always `undefined` and `useSession` took its fallback branch:

```ts
if (!id) {
  const { error, data } = await getSessions();
  return data?.sessions[0];
}
```

Every viewer URL rendered whichever session happened to be first in the list.

### The part that isn't in the issue

`Header` already derives the same id, by hand:

```ts
const { pathname } = window.location;
const currentSessionId =
  pathname.includes("sessions") && pathname.split("/").pop() !== "sessions"
    ? pathname.split("/").pop()
    : null;
```

So the `/sessions/:id` URL shape was always the intended design — the header has been relying on it this whole time. The consequence is that on `/sessions/<id>` **the header names the requested session while the viewer and console underneath render a different one.** The page contradicts itself.

Mounting a Router also removes a latent crash: `EmptyState` renders a react-router `<Link>`, which throws `useHref() may be used only in the context of a <Router> component` — reachable any time a session has no events.

## Changes

- `root-layout.tsx` — mount `BrowserRouter` with a `/sessions/:id` route plus a catch-all, so every path that renders the viewer today still renders it.
- `basename={import.meta.env.BASE_URL}` — the combined API image builds the UI with `--base=/ui` (root `Dockerfile`) and serves it behind `uiPrefix`. Without a basename the router would never match `/ui/sessions/<id>` and the deep link would silently fall back to `sessions[0]` again — the fix would look right and behave wrong.
- `header/header.tsx` — read the id with `useMatch("/sessions/:id")` instead of parsing `window.location`. The manual version also never re-read on client-side navigation.
- `containers/session-container.tsx` — on the id-less route, take the id from the resolved session rather than passing `undefined` to `SessionViewer`/`SessionConsole`. Removes two `!` assertions that were covering for a value that genuinely was undefined.

No API change. `sessionViewerUrl` still returns `getBaseUrl()`; suggestion 1 in the issue is deliberately left out, because that URL currently points at the API origin (`:3000`) while the UI is served from a different one (`:5173` in `docker-compose.yml`). Making it a deep link is worth doing but the origin question should be settled first, and it doesn't belong in the same diff. Happy to follow up if you'd like it.

## Verification

Built the UI and served `dist` with SPA fallback, then loaded `/sessions/8010bea7-…` in a real browser and recorded the API calls, once on `main` and once with this branch:

| | calls to `/v1/sessions` (list) | calls to `/v1/sessions/<id>` |
|---|---|---|
| `main` | **3** | 2 (from Header) |
| this branch | **0** | 1 |

The split on `main` is the bug made visible: Header asking for the requested session, `SessionContainer` polling the list endpoint for `sessions[0]`. After the change both read the same route, so react-query dedupes them into a single request.

Also built with `--base=/ui` to confirm the basename path compiles and routes. `tsc` and `eslint` are clean on all three files.
