### PR TITLE
fix(context): stop /context polling from slowing down the browser

### DIFF
--- a/api/src/services/cdp/cdp.service.ts
+++ b/api/src/services/cdp/cdp.service.ts
@@ -496,6 +496,7 @@ export class CDPService extends EventEmitter {
   public async shutdown(reason: ShutdownReason): Promise<void> {
     this.shuttingDown = true;
     this.logger.info(`[CDPService] Shutting down and cleaning up resources (reason: ${reason})`);
+    this.chromeSessionService.invalidate();
 
     try {
       if (this.browserInstance) {

--- a/api/src/services/context/chrome-context.service.ts
+++ b/api/src/services/context/chrome-context.service.ts
@@ -5,12 +5,20 @@ import { ChromeLocalStorageReader } from "../leveldb/localstorage.js";
 import { ChromeSessionStorageReader } from "../leveldb/sessionstorage.js";
 import { SessionData } from "./types.js";
 
+const CONTEXT_CACHE_TTL_MS = Number(process.env.CONTEXT_CACHE_TTL_MS ?? 1000);
+
 export class ChromeContextService extends EventEmitter {
   private logger: FastifyBaseLogger;
+  private cached: { key: string; at: number; data: SessionData } | null = null;
+  private inFlight: { key: string; promise: Promise<SessionData> } | null = null;
 
   constructor(logger: FastifyBaseLogger) {
     super();
     this.logger = logger;
+  }
+
+  public invalidate(): void {
+    this.cached = null;
   }
 
   /**
@@ -29,6 +37,33 @@ export class ChromeContextService extends EventEmitter {
       };
     }
 
+    const now = Date.now();
+    if (
+      this.cached &&
+      this.cached.key === userDataDir &&
+      now - this.cached.at < CONTEXT_CACHE_TTL_MS
+    ) {
+      return this.cached.data;
+    }
+
+    if (this.inFlight && this.inFlight.key === userDataDir) {
+      return this.inFlight.promise;
+    }
+
+    const promise = this.extractSessionData(userDataDir)
+      .then((data) => {
+        this.cached = { key: userDataDir, at: Date.now(), data };
+        return data;
+      })
+      .finally(() => {
+        if (this.inFlight?.promise === promise) this.inFlight = null;
+      });
+
+    this.inFlight = { key: userDataDir, promise };
+    return promise;
+  }
+
+  private async extractSessionData(userDataDir: string): Promise<SessionData> {
     this.logger.info(`Extracting session data from Chrome user data directory: ${userDataDir}`);
 
     try {

--- a/api/src/services/leveldb/localstorage.ts
+++ b/api/src/services/leveldb/localstorage.ts
@@ -51,10 +51,12 @@ export interface LocalStorageRecord {
 
 export class LocalStoreDb {
   private db: Level<Buffer, Buffer>;
+  private tmpDir: string | null;
   public records: LocalStorageRecord[] = [];
 
-  private constructor(db: Level<Buffer, Buffer>) {
+  private constructor(db: Level<Buffer, Buffer>, tmpDir: string | null = null) {
     this.db = db;
+    this.tmpDir = tmpDir;
   }
 
   public static async open(dir: string): Promise<LocalStoreDb> {
@@ -68,16 +70,20 @@ export class LocalStoreDb {
       await db.open();
       return new LocalStoreDb(db);
     } catch (err) {
-      // Attempt fallback: copy to temp directory and open there
       const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "chrome-leveldb-"));
-      await copyDirectory(dir, tmpDir);
-      const db = new Level<Buffer, Buffer>(tmpDir, {
-        createIfMissing: false,
-        keyEncoding: "buffer",
-        valueEncoding: "buffer",
-      } as any);
-      await db.open();
-      return new LocalStoreDb(db);
+      try {
+        await copyDirectory(dir, tmpDir);
+        const db = new Level<Buffer, Buffer>(tmpDir, {
+          createIfMissing: false,
+          keyEncoding: "buffer",
+          valueEncoding: "buffer",
+        } as any);
+        await db.open();
+        return new LocalStoreDb(db, tmpDir);
+      } catch (copyErr) {
+        await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+        throw copyErr;
+      }
     }
   }
 
@@ -118,9 +124,14 @@ export class LocalStoreDb {
     }
   }
 
-  public close(): void {
+  public async close(): Promise<void> {
     // @ts-ignore types mismatch but close exists
-    if (this.db.status === "open") this.db.close().catch(() => {});
+    if (this.db.status === "open") await this.db.close().catch(() => {});
+    if (this.tmpDir) {
+      const tmpDir = this.tmpDir;
+      this.tmpDir = null;
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
   }
 }
 
@@ -144,7 +155,7 @@ export class ChromeLocalStorageReader {
       }
       return result;
     } finally {
-      ldb.close();
+      await ldb.close();
     }
   }
 }

--- a/api/src/services/leveldb/sessionstorage.ts
+++ b/api/src/services/leveldb/sessionstorage.ts
@@ -34,8 +34,11 @@ export class SessionStoreDb {
   public records: SessionStorageRecord[] = [];
   private mapIdToOrigin: Map<number, string> = new Map();
 
-  private constructor(db: Level<Buffer, Buffer>) {
+  private tmpDir: string | null;
+
+  private constructor(db: Level<Buffer, Buffer>, tmpDir: string | null = null) {
     this.db = db;
+    this.tmpDir = tmpDir;
   }
 
   public static async open(dir: string): Promise<SessionStoreDb> {
@@ -49,16 +52,20 @@ export class SessionStoreDb {
       await db.open();
       return new SessionStoreDb(db);
     } catch (err) {
-      // Attempt fallback: copy to temp directory and open there
       const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "chrome-leveldb-"));
-      await copyDirectory(dir, tmpDir);
-      const db = new Level<Buffer, Buffer>(tmpDir, {
-        createIfMissing: false,
-        keyEncoding: "buffer",
-        valueEncoding: "buffer",
-      } as any);
-      await db.open();
-      return new SessionStoreDb(db);
+      try {
+        await copyDirectory(dir, tmpDir);
+        const db = new Level<Buffer, Buffer>(tmpDir, {
+          createIfMissing: false,
+          keyEncoding: "buffer",
+          valueEncoding: "buffer",
+        } as any);
+        await db.open();
+        return new SessionStoreDb(db, tmpDir);
+      } catch (copyErr) {
+        await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+        throw copyErr;
+      }
     }
   }
 
@@ -132,9 +139,14 @@ export class SessionStoreDb {
     }
   }
 
-  public close(): void {
+  public async close(): Promise<void> {
     // @ts-ignore types mismatch but close exists
-    if (this.db.status === "open") this.db.close().catch(() => {});
+    if (this.db.status === "open") await this.db.close().catch(() => {});
+    if (this.tmpDir) {
+      const tmpDir = this.tmpDir;
+      this.tmpDir = null;
+      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
   }
 }
 
@@ -223,7 +235,7 @@ export class ChromeSessionStorageReader {
 
       return result;
     } finally {
-      sdb.close();
+      await sdb.close();
     }
   }
 }


### PR DESCRIPTION
## Description

Chrome holds an exclusive lock on its LevelDB while running, so the direct Level.open() in LocalStoreDb.open() always fails against a live browser. The catch branch written as a fallback is therefore the normal path for every request. Clients can poll this endpoint several times a second.

Those copies run on the libuv threadpool (4 threads by default). Once saturated, every other async fs and DNS operation queues behind them, including the ones Fastify needs to answer requests, so the process starts slowing down entirely.

This caches extractions briefly, and collapses concurrent polls into one.