### PR TITLE
fix(ui): render session logs for both emitted record shapes

### DIFF
--- a/ui/src/components/sessions/session-console/session-logs.tsx
+++ b/ui/src/components/sessions/session-console/session-logs.tsx
@@ -38,6 +38,35 @@ export default function SessionLogs({ id }: { id: string }) {
     return "var(--gray-11)";
   };
 
+  // Two record shapes reach this component:
+  //  - the CDP instrumentation nests the payload under a key named after the event type
+  //    (`console`, `request`, `response`, ... — see api/src/services/cdp/instrumentation/types.ts)
+  //  - selenium.service.ts still sends the payload as a JSON string on `text`
+  // Reading `text` unconditionally made `JSON.parse(undefined)` throw on every CDP record,
+  // which unmounted the whole tab. ExtensionEvent is flat, so falling back to the record
+  // itself keeps `message`/`logLevel` reachable.
+  const logToBody = (log: Record<string, any>): Record<string, any> => {
+    if (typeof log.text === "string") {
+      try {
+        return JSON.parse(log.text);
+      } catch {
+        return { message: log.text };
+      }
+    }
+    return (
+      log.console ??
+      log.request ??
+      log.response ??
+      log.responseBody ??
+      log.navigation ??
+      log.error ??
+      log.interaction ??
+      log.data ??
+      log.cdp ??
+      log
+    );
+  };
+
   const logTypeToFormat = (type: string, log: Record<string, any>) => {
     if (type === "Console") {
       if (log.message) {
@@ -63,7 +92,7 @@ export default function SessionLogs({ id }: { id: string }) {
       {logs.length === 0 && <p className="text-gray-400">No new logs...</p>}
       {logs &&
         logs.slice(-40).map((log) => {
-          const logBody = JSON.parse(log.text);
+          const logBody = logToBody(log);
           const cleanMessage = logTypeToFormat(log.type, logBody);
 
           return (


### PR DESCRIPTION
Fixes #357.

## Problem

`SessionLogs` unconditionally did `JSON.parse(log.text)`, but the CDP instrumentation nests each payload under a key named after the event type and sets no top-level `text`:

```json
{"type":"Console",  "timestamp":"...", "pageId":"...", "console":{"level":"log","text":"hello"}}
{"type":"Request",  "timestamp":"...", "pageId":"...", "request":{"method":"GET","url":"https://example.com/"}}
{"type":"Response", "timestamp":"...", "pageId":"...", "response":{"status":200,"url":"https://example.com/"}}
```

`JSON.parse(undefined)` coerces its argument to the string `"undefined"` and throws:

```
SyntaxError: "undefined" is not valid JSON
```

Because the throw happens inside `map` during render, React unmounts the whole tab — the panel goes blank with no partial output and nothing surfaced to the user. It reproduces on any session as soon as a single record arrives.

## Why not just swap `text` for the nested payload

Both shapes are live in the tree. `selenium.service.ts` still emits the older form:

https://github.com/steel-dev/steel-browser/blob/main/api/src/services/selenium.service.ts#L50-L52

```ts
type: BrowserEventType.Console,
text: JSON.stringify({ type: BrowserEventType.Console, message: `${data}` }),
```

while the CDP path emits the nested form described in `api/src/services/cdp/instrumentation/types.ts`. So this resolves both rather than replacing one with the other.

## Change

One helper, and the call site now uses it:

```ts
const logToBody = (log: Record<string, any>): Record<string, any> => {
  if (typeof log.text === "string") {
    try { return JSON.parse(log.text); } catch { return { message: log.text }; }
  }
  return (
    log.console ?? log.request ?? log.response ?? log.responseBody ??
    log.navigation ?? log.error ?? log.interaction ?? log.data ?? log.cdp ?? log
  );
};
```

Notes on the details:

- The key list mirrors `BrowserEventUnion` in `api/src/services/cdp/instrumentation/types.ts`.
- A generic `log[log.type.toLowerCase()]` does **not** work — `BrowserInteraction` carries its payload under `interaction`, and the three CDP event types all share `cdp`.
- `ExtensionEvent` is flat (`message`, `logLevel`, `loc` at the top level), so falling back to the record itself keeps it rendering.
- Malformed `text` degrades to `{ message: text }` instead of throwing, so one bad record can never blank the tab again.
- `logTypeToFormat` already expected exactly the nested payload (`log.method`/`log.url` for `Request`, `log.text` for `Console`), so no formatter change was needed.

## Verification

Ran the resolver + the existing formatter over the record shapes captured off `wss://<host>/v1/sessions/logs` on a self-hosted instance, plus the legacy and malformed cases:

```
  Console             -> steel-log-probe
  Console             -> warn-probe
  Request             -> [GET] https://example.com/
  Response            -> [404] https://example.com/missing
  Navigation          -> https://example.com/
  BrowserInteraction  -> {"action":"navigate","eventType":"framenavigated",...}
  Error               -> boom                      (nested ErrorEvent)
  Console             -> from ext                  (flat ExtensionEvent)
  Console             -> selenium line             (legacy JSON-string on text)
  Console             -> not json at all           (malformed text)

ALL RENDERED, NO THROWS
```

The same first record under the old code: `SyntaxError: "undefined" is not valid JSON`.

I also applied the equivalent substitution to the served bundle on a running self-hosted instance before writing this, and the tab renders live traffic with no page errors:

```
09:25:24 [Console] CONSOLE-PROBE-12345
09:25:24 [Console] a-warning-here
09:24:48 [Request]  [GET] https://example.com/
09:24:48 [Response] [200] https://example.com/
09:24:48 [Navigation] https://example.com/
```

`npm run lint -w ui` and `npm run build -w ui` both pass.
